### PR TITLE
Enable DPI scaling for pattern editor

### DIFF
--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -42,6 +42,11 @@
 #include "WinInet.h"		// // //
 #pragma comment(lib, "wininet.lib")
 
+// 0CC uses AfxRegSetValue() and AfxGetModuleShortFileName(),
+// found in the undocumented header afxpriv.h.
+// These functions shouldn't have been used... but here we are.
+#include <afxpriv.h>
+
 // Single instance-stuff
 const TCHAR FT_SHARED_MUTEX_NAME[]	= _T("FamiTrackerMutex");	// Name of global mutex
 const TCHAR FT_SHARED_MEM_NAME[]	= _T("FamiTrackerWnd");		// Name of global memory area

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -770,10 +770,10 @@ void CMainFrame::ResizeFrameWindow()
 			CRect rect;
 			m_wndVerticalControlBar.GetClientRect(&rect);
 
-			Height = rect.Height() - DPI::SY(CPatternEditor::HEADER_HEIGHT - 2);		// // //
+			Height = rect.Height() - DPI::SY(CPatternEditor::HEADER_HEIGHT_NODPI - 2);		// // //
 			Width = m_pFrameEditor->CalcWidth(Channels);
 
-			m_pFrameEditor->MoveWindow(DPI::SX(2), DPI::SY(CPatternEditor::HEADER_HEIGHT + 1), DPI::SX(Width), Height);		// // //
+			m_pFrameEditor->MoveWindow(DPI::SX(2), DPI::SY(CPatternEditor::HEADER_HEIGHT_NODPI + 1), DPI::SX(Width), Height);		// // //
 
 			// Move frame controls
 			m_wndFrameControls.MoveWindow(DPI::Rect(4, 10, 150, 26));

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -305,7 +305,7 @@ void CPatternEditor::ApplyColorScheme()
 
 	if (m_fontCourierNew.m_hObject == NULL)		// // // smaller
 		m_fontCourierNew.CreateFont(
-			DPI::SY(14), 0, 0, 0, 0, FALSE, FALSE, FALSE, 0, 0, 0, DRAFT_QUALITY, DEFAULT_PITCH | FF_DONTCARE, _T("Courier New"));
+			DPI::SY(14), 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE, 0, 0, 0, DRAFT_QUALITY, DEFAULT_PITCH | FF_DONTCARE, _T("Courier New"));
 
 	// Cache some colors
 	m_colSeparator	= BLEND(ColBackground, (ColBackground ^ 0xFFFFFF), SHADE_LEVEL.SEPARATOR);

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -274,7 +274,7 @@ void CPatternEditor::ApplyColorScheme()
 	CalcLayout();
 
 	// Create pattern font
-	memset(&LogFont, 0, sizeof LOGFONT);
+	memset(&LogFont, 0, sizeof(LOGFONT));
 	memcpy(LogFont.lfFaceName, FontName, _tcslen(FontName));
 
 	LogFont.lfHeight = -m_iPatternFontSize;
@@ -288,7 +288,7 @@ void CPatternEditor::ApplyColorScheme()
 	m_fontPattern.CreateFontIndirect(&LogFont);
 
 	// Create header font
-	memset(&LogFont, 0, sizeof LOGFONT);
+	memset(&LogFont, 0, sizeof(LOGFONT));
 	memcpy(LogFont.lfFaceName, HeaderFace, _tcslen(HeaderFace));
 
 	LogFont.lfHeight = -DEFAULT_HEADER_FONT_SIZE;

--- a/Source/PatternEditor.h
+++ b/Source/PatternEditor.h
@@ -281,17 +281,8 @@ private:
 
 public:
 	// Public consts
-	static const int HEADER_HEIGHT;
-	// // //
-private:
-	// Private consts
-	static LPCTSTR DEFAULT_HEADER_FONT;
-	static const int DEFAULT_FONT_SIZE;
-	static const int DEFAULT_HEADER_FONT_SIZE;
-
-	static const int HEADER_CHAN_START;
-	static const int HEADER_CHAN_HEIGHT;
-	static const int ROW_HEIGHT;
+	static const int HEADER_HEIGHT_NODPI;
+	const int HEADER_HEIGHT;
 
 	// Variables
 public:

--- a/Source/stdafx.h
+++ b/Source/stdafx.h
@@ -68,7 +68,7 @@
 #ifndef _AFX_NO_AFXCMN_SUPPORT
 #include <afxcmn.h>			// MFC support for Windows Common Controls
 #endif // _AFX_NO_AFXCMN_SUPPORT
-#include <afxdhtml.h>
+#include <afxadv.h>
 #include <afxdlgs.h>
 
 #include <afxole.h>        // MFC OLE support


### PR DESCRIPTION
On high-DPI screens, if the user turns on application v1 DPI scaling for famitracker, the pattern editor will paint at a larger size.

## Issues:

- Some people may be more used to the current small text, even though it's probably an error.
- The register view doesn't scale perfectly.
- More testing should be performed.