### PR TITLE
Fix CMake MFC detection and link flag conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# CMake configuration
+/cmake_user_begin.cmake
+/cmake_user_end.cmake
+
 # Driver build process
 /Source/drivers/asm/build/log.txt
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.10)
 
 set(project "Dn_FamiTracker")
 set(exe "Dn_FamiTracker")
+include(cmake_user_begin.cmake OPTIONAL)
 
 project(${project})
 
@@ -66,3 +67,5 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND CMAKE_BUILD_TYPE MATCHES "Release")
         COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR}
     )
 endif()
+
+include(cmake_user_end.cmake OPTIONAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(${project})
 # Simpler approach (unimplemented): https://stackoverflow.com/questions/11580748/cmake-mfc
     # does not set mt vs md
 
+# Configure MFC
 if (CMAKE_BUILD_TYPE MATCHES DEBUG)
     # Debug build requires dynamic MFC.
     set(STATIC_MSVCRT 0)
@@ -20,13 +21,7 @@ else ()
     # Otherwise link MFC statically.
     set(STATIC_MSVCRT 1)
 endif ()
-
-set(mfcin cmake/mfc.cmake.in)
-set(mfc ${CMAKE_CURRENT_BINARY_DIR}/mfc.cmake)
-
-# Configure MFC
-configure_file(${mfcin} ${mfc} @ONLY)
-include(${mfc})
+include(cmake/mfc.cmake)
 
 
 # compiling

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 # TODO: https://pabloariasal.github.io/2018/02/19/its-time-to-do-cmake-right/
 
 cmake_minimum_required(VERSION 3.10)
-project(Dn_FamiTracker)
+
+set(project "Dn_FamiTracker")
+set(exe "Dn_FamiTracker")
+
+project(${project})
 
 
 # MFC based off https://github.com/Kitware/CMake/blob/master/Tests/MFC/CMakeLists.txt
@@ -27,42 +31,43 @@ include(${mfc})
 
 # compiling
 include(cmake/exe.cmake)
+target_compile_features(${exe} PRIVATE cxx_std_17)
+
 if(COMMAND target_precompile_headers)
-    target_precompile_headers(${PROJECT_NAME} PRIVATE
+    target_precompile_headers(${exe} PRIVATE
         "$<$<COMPILE_LANGUAGE:CXX>:Source/stdafx.cpp>"
     )
 endif()
 
 
 # linking
-TARGET_LINK_LIBRARIES(${PROJECT_NAME}
+TARGET_LINK_LIBRARIES(${exe}
         Dbghelp winmm comctl32 dsound dxguid Version)
-
-
-# Generating .pdb files
-if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND CMAKE_BUILD_TYPE MATCHES "Release")
-   target_compile_options(${PROJECT_NAME} PRIVATE /Zi)
-
-   # Tell linker to include symbol data
-    set_target_properties(${PROJECT_NAME} PROPERTIES
-        LINK_FLAGS "/INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF"
-    )
-
-    # Set file name & location
-    set_target_properties(${PROJECT_NAME} PROPERTIES
-        COMPILE_PDB_NAME ${PROJECT_NAME}
-        COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR}
-    )
-endif()
-
 
 # 0CC-FamiTracker.rc includes res/0CC-FamiTracker.manifest.
 # To prevent manifest linking errors:
 # - res/0CC-FamiTracker.manifest MUST not be in add_executable().
 # - /MANIFEST:NO must be passed into the linker.
+set_property(
+    TARGET ${exe}
+    APPEND_STRING PROPERTY LINK_FLAGS
+    " /MANIFEST:NO"
+)
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
-set_target_properties(${PROJECT_NAME} PROPERTIES
-        LINK_FLAGS
-        /MANIFEST:NO)
-#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /MANIFEST:NO")
+# Generating .pdb files
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC" AND CMAKE_BUILD_TYPE MATCHES "Release")
+   target_compile_options(${exe} PRIVATE /Zi)
+
+   # Tell linker to include symbol data
+    set_property(
+        TARGET ${exe}
+        APPEND_STRING PROPERTY LINK_FLAGS
+        " /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF"
+    )
+
+    # Set file name & location
+    set_target_properties(${exe} PROPERTIES
+        COMPILE_PDB_NAME ${exe}
+        COMPILE_PDB_OUTPUT_DIR ${CMAKE_BINARY_DIR}
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,10 @@ project(${project})
 
 if (CMAKE_BUILD_TYPE MATCHES DEBUG)
     # Debug build requires dynamic MFC.
-    set(CMAKE_MFC_FLAG_VALUE 0)
+    set(STATIC_MSVCRT 0)
 else ()
     # Otherwise link MFC statically.
-    set(CMAKE_MFC_FLAG_VALUE 1)
+    set(STATIC_MSVCRT 1)
 endif ()
 
 set(mfcin cmake/mfc.cmake.in)

--- a/cmake/exe.cmake
+++ b/cmake/exe.cmake
@@ -1,7 +1,7 @@
 include_directories(.)
 include_directories(Source)
 
-add_executable(${PROJECT_NAME}
+add_executable(${exe}
         WIN32
 
         res/About.bmp

--- a/cmake/mfc.cmake
+++ b/cmake/mfc.cmake
@@ -28,16 +28,15 @@ macro(msvc_link_to_static_crt)
 endmacro()
 
 
-set(CMAKE_MFC_FLAG "@STATIC_MSVCRT@")
-if ("${CMAKE_MFC_FLAG}" STREQUAL "")
+if ("${STATIC_MSVCRT}" STREQUAL "")
     message(FATAL_ERROR "Did not set STATIC_MSVCRT when including MFC CMake")
 endif()
 
 # First set static/dynamic MSVCRT...
-if("${CMAKE_MFC_FLAG}" STREQUAL "1")
+if(STATIC_MSVCRT)
     msvc_link_to_static_crt()
 else()
-    # VS generators add this automatically based on the CMAKE_MFC_FLAG value,
+    # VS generators add this automatically based on the STATIC_MSVCRT value,
     # but generators matching "Make" require:
     add_definitions(-D_AFXDLL)
 endif()
@@ -48,7 +47,7 @@ IF (NOT MFC_FOUND)
     MESSAGE(FATAL_ERROR "MFC Could not be found during the MFC test")
 ENDIF()
 
-if("${CMAKE_MFC_FLAG}" STREQUAL "2")
+if("${STATIC_MSVCRT}" STREQUAL "2")
     set(CMAKE_INSTALL_MFC_LIBRARIES ON)
     include(InstallRequiredSystemLibraries)
 endif()

--- a/cmake/mfc.cmake.in
+++ b/cmake/mfc.cmake.in
@@ -33,11 +33,7 @@ if ("${CMAKE_MFC_FLAG}" STREQUAL "")
     message(FATAL_ERROR "Did not set CMAKE_MFC_FLAG_VALUE when including MFC CMake")
 endif()
 
-FIND_PACKAGE(MFC)
-IF (NOT MFC_FOUND)
-    MESSAGE(FATAL_ERROR "MFC Could not be found during the MFC test")
-ENDIF()
-
+# First set static/dynamic MSVCRT...
 if("${CMAKE_MFC_FLAG}" STREQUAL "1")
     msvc_link_to_static_crt()
 else()
@@ -45,6 +41,12 @@ else()
     # but generators matching "Make" require:
     add_definitions(-D_AFXDLL)
 endif()
+
+# Then call FindMFC.cmake (behavior depends on static/dynamic CRT).
+FIND_PACKAGE(MFC)
+IF (NOT MFC_FOUND)
+    MESSAGE(FATAL_ERROR "MFC Could not be found during the MFC test")
+ENDIF()
 
 if("${CMAKE_MFC_FLAG}" STREQUAL "2")
     set(CMAKE_INSTALL_MFC_LIBRARIES ON)

--- a/cmake/mfc.cmake.in
+++ b/cmake/mfc.cmake.in
@@ -28,9 +28,9 @@ macro(msvc_link_to_static_crt)
 endmacro()
 
 
-set(CMAKE_MFC_FLAG "@CMAKE_MFC_FLAG_VALUE@")
+set(CMAKE_MFC_FLAG "@STATIC_MSVCRT@")
 if ("${CMAKE_MFC_FLAG}" STREQUAL "")
-    message(FATAL_ERROR "Did not set CMAKE_MFC_FLAG_VALUE when including MFC CMake")
+    message(FATAL_ERROR "Did not set STATIC_MSVCRT when including MFC CMake")
 endif()
 
 # First set static/dynamic MSVCRT...

--- a/cmake_user_begin.cmake.example
+++ b/cmake_user_begin.cmake.example
@@ -1,0 +1,1 @@
+# cmake_user_begin is called before project(). You can set global options.

--- a/cmake_user_end.cmake.example
+++ b/cmake_user_end.cmake.example
@@ -1,0 +1,1 @@
+# In cmake_user_end, you can modify individual targets.


### PR DESCRIPTION
Previously the MFC detection would sometimes fail due to mismatched /MT vs. /MD. This has been fixed. MFC detection is still erroneously(?) cached even when build flags change.

Previously, reordering `set_target_properties(...LINK_FLAGS)` would cause set of link flags to overwrite the other, breaking the manifest and theming. Now the options are appended instead.

I also renamed the target to the `${exe}` variable because I find it clearer.