### PR TITLE
Fix UB caught on asan branch

### DIFF
--- a/Source/ChannelHandler.cpp
+++ b/Source/ChannelHandler.cpp
@@ -294,7 +294,7 @@ void CChannelHandler::WriteEchoBuffer(stChanNote *NoteData, int Pos, int EffColu
 	case ECHO: Value = ECHO_BUFFER_ECHO + NoteData->Octave; break;
 	default:
 		Value = MIDI_NOTE(NoteData->Octave, NoteData->Note);
-		for (int i = EffColumns; i >= 0; i--) {
+		for (int i = EffColumns - 1; i >= 0; i--) {
 			const int Param = NoteData->EffParam[i] & 0x0F;
 			if (NoteData->EffNumber[i] == EF_SLIDE_UP) {
 				Value += Param;

--- a/Source/SequenceParser.h
+++ b/Source/SequenceParser.h
@@ -60,6 +60,8 @@ public:
 	virtual void OnStart() { }
 	/*!	\brief Called after converting an MML string. */
 	virtual void OnFinish() { }
+
+    virtual ~CSeqConversionBase() = default;
 };
 
 class CSeqConversionDefault : public CSeqConversionBase


### PR DESCRIPTION
My unpublished CMake MSVC asan branch is hacky. Picking the right runtime is difficult, and my current code is more superstition than logic. Static asan results in crashing when you open a file dialog. Dynamic asan requires the DLLs in PATH for the binary to load.

I couldn't get asan to work through MSBuild/sln/vcxproj. It can't even be enabled until you upgrade the compiler to v142 (2019), and I recall getting linking errors.