### PR TITLE
Update required link libraries in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 # linking
 TARGET_LINK_LIBRARIES(${exe}
-        Dbghelp winmm comctl32 dsound dxguid Version)
+        Dbghelp winmm comctl32 dsound Version htmlhelp)
 
 # Dn-FamiTracker.rc includes res/Dn-FamiTracker.manifest.
 # To prevent manifest linking errors:


### PR DESCRIPTION
The dxguid.lib requirement was removed by me in 2020, and the htmlhelp requirement was added when @Gumball2415 added HTML help support more recently.

I'm not sure if this commit affects the build process or not. Maybe removing dxguid allows it to build without the DirectX SDK installed. Adding htmlhelp (for linking) may add dependencies, but probably not since the program already depends on HTML help headers (for compiling).