### PR TITLE
Refactor CAPU reconfiguration, make FDS lowpass filter configurable in settings

### DIFF
--- a/Source/APU/APU.cpp
+++ b/Source/APU/APU.cpp
@@ -421,7 +421,6 @@ void CAPU::SetChipLevel(chip_level_t Chip, float Level)
 
 void CAPU::SetNamcoMixing(bool bLinear)		// // //
 {
-	m_pMixer->SetNamcoMixing(bLinear);
 	m_pN163->SetMixingMethod(bLinear);
 }
 

--- a/Source/APU/APU.cpp
+++ b/Source/APU/APU.cpp
@@ -465,9 +465,9 @@ CRegisterState *CAPU::GetRegState(int Chip, int Reg) const		// // //
 }
 
 
-void CAPUConfig::SetupMixer(int LowCut, int HighCut, int HighDamp, int Volume)
+void CAPUConfig::SetupMixer(int LowCut, int HighCut, int HighDamp, int Volume, int FDSLowpass)
 {
-	m_MixerConfig = MixerConfig{ LowCut, HighCut, HighDamp, float(Volume) / 100.0f };
+	m_MixerConfig = MixerConfig{ LowCut, HighCut, HighDamp, float(Volume) / 100.0f, FDSLowpass };
 }
 
 void CAPUConfig::SetChipLevel(chip_level_t Chip, float LeveldB)

--- a/Source/APU/APU.cpp
+++ b/Source/APU/APU.cpp
@@ -190,13 +190,6 @@ void CAPU::Reset()
 #endif
 }
 
-void CAPU::SetupMixer(int LowCut, int HighCut, int HighDamp, int Volume) const
-{
-	// New settings
-	m_pMixer->UpdateMixing(LowCut, HighCut, HighDamp, float(Volume) / 100.0f);
-	m_pVRC7->SetVolume((float(Volume) / 100.0f) * m_fLevelVRC7);
-}
-
 void CAPU::SetExternalSound(uint8_t Chip)
 {
 	// Initialize list of active sound chips.
@@ -405,20 +398,6 @@ void CAPU::Log()
 }
 #endif
 
-void CAPU::SetChipLevel(chip_level_t Chip, float Level)
-{
-	float fLevel = powf(10, Level / 20.0f);		// Convert dB to linear
-
-	switch (Chip) {
-		case CHIP_LEVEL_VRC7:
-			m_fLevelVRC7 = fLevel;
-			break;
-			// // // 050B
-		default:
-			m_pMixer->SetChipLevel(Chip, fLevel);
-	}
-}
-
 void CAPU::SetNamcoMixing(bool bLinear)		// // //
 {
 	m_pN163->SetMixingMethod(bLinear);
@@ -482,5 +461,77 @@ CRegisterState *CAPU::GetRegState(int Chip, int Reg) const		// // //
 	case SNDCHIP_N163: return PtrGetRegState(*m_pN163);
 	case SNDCHIP_S5B:  return PtrGetRegState(*m_pS5B);
 	default: AfxDebugBreak(); return nullptr;
+	}
+}
+
+
+void CAPUConfig::SetupMixer(int LowCut, int HighCut, int HighDamp, int Volume)
+{
+	m_MixerConfig = MixerConfig{ LowCut, HighCut, HighDamp, float(Volume) / 100.0f };
+}
+
+void CAPUConfig::SetChipLevel(chip_level_t Chip, float LeveldB)
+{
+	float LevelLinear = powf(10, LeveldB / 20.0f);		// Convert dB to linear
+	m_ChipLevels[Chip] = LevelLinear;
+}
+
+CAPUConfig::~CAPUConfig() noexcept(false) {
+	// if unwinding, skip reconfiguring CAPU.
+	// it would be a *lot* easier to simply not call ~CAPUConfig in the unwind table...
+	// but C++ makes many simple things complicated and slow.
+	if (std::uncaught_exceptions() != m_UncaughtExceptions) {
+		return;
+	}
+
+	bool mixingDirty = false;
+
+	// Writes to CMixer::m_iExternalChip.
+	// This is read by CMixer::GetAttenuation(), which is called by CMixer::RecomputeMixing().
+	if (m_ExternalSound) {
+		// This eagerly calls m_pMixer->SetClockRate(m_pMixer->BlipBuffer.clock_rate())
+		// (reinitializing the clock rate to the same value, but to a different set of expansion chips).
+		// We don't know if BlipBuffer.clock_rate() is initialized yet or not,
+		// but if clock rate initialization happens later,
+		// CAPU::ChangeMachineRate() will call CMixer::SetClockRate() a second time.
+		// Ugly, but it works.
+		m_APU->SetExternalSound(*m_ExternalSound);
+		mixingDirty = true;
+	}
+
+	// Writes to CAPU::m_fLevelVRC7 and CMixer::m_fLevel[...].
+	// This is read by CMixer::RecomputeMixing().
+	for (int chip = 0; chip < CHIP_LEVEL_COUNT; chip++) {
+		if (m_ChipLevels[chip]) {
+			auto level = *m_ChipLevels[chip];
+			switch (chip) {
+			case CHIP_LEVEL_VRC7:
+				m_APU->m_fLevelVRC7 = level;
+				break;
+			default:
+				m_Mixer->SetChipLevel((chip_level_t)chip, level);
+				mixingDirty = true;
+				break;
+			}
+		}
+	}
+
+	// Writes to CMixer::m_MixerConfig.
+	// This is read by CMixer::RecomputeMixing().
+	if (m_MixerConfig) {
+		auto& cfg = *m_MixerConfig;
+		// Volume does not decrease as you enable expansion chips.
+		// This is probably a bug, but it's too late to change it now
+		// (it would break old modules).
+		m_APU->m_pVRC7->SetVolume(cfg.OverallVol * m_APU->m_fLevelVRC7);
+
+		m_Mixer->SetMixing(cfg);
+		mixingDirty = true;
+	}
+
+	if (mixingDirty) {
+		// Volume decreases exponentially as you enable expansion chips linearly.
+		// This is probably a bug, but it might be too late to change it now.
+		m_Mixer->RecomputeMixing();
 	}
 }

--- a/Source/APU/APU.h
+++ b/Source/APU/APU.h
@@ -26,6 +26,7 @@
 //#define LOGGING
 
 #include "../Common.h"
+// TODO switch to MixerCommon.h, with forward-declaration of CMixer, plus MixerConfig
 #include "Mixer.h"
 
 #include <vector>
@@ -183,7 +184,7 @@ public:
 	}
 
 	void SetChipLevel(chip_level_t Chip, float LeveldB);
-	void SetupMixer(int LowCut, int HighCut, int HighDamp, int Volume);
+	void SetupMixer(int LowCut, int HighCut, int HighDamp, int Volume, int FDSLowpass);
 
 	/// Commit changes if no exception is active.
 	///

--- a/Source/APU/FDS.h
+++ b/Source/APU/FDS.h
@@ -25,6 +25,8 @@
 #include "ChannelLevelState.h"
 #include "Blip_Buffer/Blip_Buffer.h"
 #include "APU/mesen/FdsAudio.h"
+#include "FamiTracker.h"
+#include "Settings.h"
 
 class CMixer;
 
@@ -43,9 +45,15 @@ public:
 	int GetChannelLevel(int Channel) override;
 	int GetChannelLevelRange(int Channel) const override;
 
+	void UpdateFdsFilter(int CutoffHz);
 	void UpdateMixLevel(double v);
 
 private:
+	void RecomputeFdsFilter();
+
+private:
+	int m_CutoffHz;
+
 	FdsAudio m_FDS;
 
 	Blip_Buffer m_BlipFDS;

--- a/Source/APU/Mixer.cpp
+++ b/Source/APU/Mixer.cpp
@@ -102,11 +102,6 @@ void CMixer::ExternalSound(int Chip)
 	UpdateMixing(m_iLowCut, m_iHighCut, m_iHighDamp, m_fOverallVol);
 }
 
-void CMixer::SetNamcoMixing(bool bLinear)		// // //
-{
-	m_bNamcoMixing = bLinear;
-}
-
 void CMixer::SetChipLevel(chip_level_t Chip, float Level)
 {
 	switch (Chip) {

--- a/Source/APU/Mixer.cpp
+++ b/Source/APU/Mixer.cpp
@@ -208,6 +208,8 @@ void CMixer::RecomputeMixing()
 	chip2A03.UpdateMixingAPU2(Volume * m_fLevelAPU2);
 	chipFDS.UpdateMixLevel(Volume * m_fLevelFDS);
 
+	chipFDS.UpdateFdsFilter(m_MixerConfig.FDSLowpass);
+
 	SynthVRC6.volume(Volume * 3.98333f * m_fLevelVRC6, 500);
 	SynthMMC5.volume(Volume * 1.18421f * m_fLevelMMC5, 130);
 	SynthS5B.volume(Volume * m_fLevelS5B, 1600);  // Not checked

--- a/Source/APU/Mixer.h
+++ b/Source/APU/Mixer.h
@@ -48,6 +48,7 @@ struct MixerConfig {
 	int HighCut = 0;
 	int HighDamp = 0;
 	float OverallVol = 0;
+	int FDSLowpass = 2000;
 };
 
 class CMixer

--- a/Source/APU/Mixer.h
+++ b/Source/APU/Mixer.h
@@ -35,12 +35,20 @@ enum chip_level_t {
 	CHIP_LEVEL_MMC5,
 	CHIP_LEVEL_FDS,
 	CHIP_LEVEL_N163,
-	CHIP_LEVEL_S5B
+	CHIP_LEVEL_S5B,
+	CHIP_LEVEL_COUNT
 };
 
 class C2A03;
 class CFDS;
 class CAPU;
+
+struct MixerConfig {
+	int LowCut = 0;
+	int HighCut = 0;
+	int HighDamp = 0;
+	float OverallVol = 0;
+};
 
 class CMixer
 {
@@ -51,7 +59,10 @@ public:
 	void	ExternalSound(int Chip);
 
 	void	AddValue(int ChanID, int Chip, int Value, int AbsValue, int FrameCycles);
-	void	UpdateMixing(int LowCut, int HighCut, int HighDamp, float OverallVol);
+	void	SetMixing(MixerConfig cfg) {
+		m_MixerConfig = cfg;
+	}
+	void	RecomputeMixing();
 
 	bool	AllocateBuffer(unsigned int Size, uint32_t SampleRate, uint8_t NrChannels);
 	Blip_Buffer& GetBuffer() {
@@ -125,10 +136,7 @@ private:
 	uint32_t	m_iChanLevelFallOff[CHANNELS];
 
 	int			m_iMeterDecayRate;		// // // 050B
-	int			m_iLowCut;
-	int			m_iHighCut;
-	int			m_iHighDamp;
-	float		m_fOverallVol;
+	MixerConfig m_MixerConfig;
 
 	float		m_fLevelAPU1;
 	float		m_fLevelAPU2;

--- a/Source/APU/Mixer.h
+++ b/Source/APU/Mixer.h
@@ -70,7 +70,6 @@ public:
 	int32_t	GetChanOutput(uint8_t Chan) const;
 	void	SetChipLevel(chip_level_t Chip, float Level);
 	uint32_t	ResampleDuration(uint32_t Time) const;
-	void	SetNamcoMixing(bool bLinear);		// // //
 	void	SetNamcoVolume(float fVol);
 
 	int		GetMeterDecayRate() const;		// // // 050B
@@ -138,8 +137,6 @@ private:
 	float		m_fLevelFDS;
 	float		m_fLevelN163;
 	float		m_fLevelS5B;		// // // 050B
-
-	bool		m_bNamcoMixing;		// // //
 
 	friend class CAPU;
 };

--- a/Source/ConfigEmulation.cpp
+++ b/Source/ConfigEmulation.cpp
@@ -65,7 +65,7 @@ BOOL CConfigEmulation::OnInitDialog()
 
 	// FDS
 	CSliderCtrl* pFDSLowpass = static_cast<CSliderCtrl*>(GetDlgItem(IDC_SLIDER_FDS_LOWPASS));
-	pFDSLowpass->SetRange(0, 20000);
+	pFDSLowpass->SetRange(0, 8000);
 	pFDSLowpass->SetPos(pSettings->Emulation.iFDSLowpass);
 
 	// N163
@@ -95,6 +95,10 @@ BOOL CConfigEmulation::OnApply()
 {
 	CSettings* pSettings = theApp.GetSettings();
 	CSoundGen* pSoundGen = theApp.GetSoundGenerator();
+
+	// FDS
+	CSliderCtrl* pFDSLowpass = static_cast<CSliderCtrl*>(GetDlgItem(IDC_SLIDER_FDS_LOWPASS));
+	pSettings->Emulation.iFDSLowpass = pFDSLowpass->GetPos();
 
 	// N163
 	pSettings->Emulation.bNamcoMixing = m_bDisableNamcoMultiplex;

--- a/Source/Settings.h
+++ b/Source/Settings.h
@@ -251,11 +251,8 @@ public:
 	struct {
 		// FDS
 		int		iFDSLowpass;
-		int		iFDSEmulator;
 		// N163
 		bool	bNamcoMixing;		// // //
-		// S5B
-		int		iS5BEmulator;
 		// VRC7
 		int		iVRC7Patch;
 	} Emulation;

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -775,7 +775,12 @@ bool CSoundGen::ResetAudioDevice()
 		config.SetChipLevel(CHIP_LEVEL_S5B, float(pSettings->ChipLevels.iLevelS5B / 10.0f));
 
 		// Update blip-buffer filtering
-		config.SetupMixer(pSettings->Sound.iBassFilter, pSettings->Sound.iTrebleFilter, pSettings->Sound.iTrebleDamping, pSettings->Sound.iMixVolume);
+		config.SetupMixer(
+			pSettings->Sound.iBassFilter,
+			pSettings->Sound.iTrebleFilter,
+			pSettings->Sound.iTrebleDamping,
+			pSettings->Sound.iMixVolume,
+			pSettings->Emulation.iFDSLowpass);
 	}
 
 	m_bAudioClipping = false;

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -761,26 +761,22 @@ bool CSoundGen::ResetAudioDevice()
 
 	currN163LevelOffset = m_pDocument->GetN163LevelOffset();
 
-	m_pAPU->SetChipLevel(CHIP_LEVEL_APU1, float(pSettings->ChipLevels.iLevelAPU1 / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_APU2, float(pSettings->ChipLevels.iLevelAPU2 / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_VRC6, float(pSettings->ChipLevels.iLevelVRC6 / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_VRC7, float(pSettings->ChipLevels.iLevelVRC7 / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_MMC5, float(pSettings->ChipLevels.iLevelMMC5 / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_FDS, float(pSettings->ChipLevels.iLevelFDS / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_N163, float(
-		(pSettings->ChipLevels.iLevelN163 + currN163LevelOffset) / 10.0f));
-	m_pAPU->SetChipLevel(CHIP_LEVEL_S5B, float(pSettings->ChipLevels.iLevelS5B / 10.0f));
-/*
-	m_pAPU->SetChipLevel(SNDCHIP_NONE, 0);//pSettings->ChipLevels.iLevel2A03);
-	m_pAPU->SetChipLevel(SNDCHIP_VRC6, 0);//pSettings->ChipLevels.iLevelVRC6);
-	m_pAPU->SetChipLevel(SNDCHIP_VRC7, 0);//pSettings->ChipLevels.iLevelVRC7);
-	m_pAPU->SetChipLevel(SNDCHIP_MMC5, 0);//pSettings->ChipLevels.iLevelMMC5);
-	m_pAPU->SetChipLevel(SNDCHIP_FDS, 0);//pSettings->ChipLevels.iLevelFDS);
-//	m_pAPU->SetChipLevel(SNDCHIP_N163, pSettings->ChipLevels.iLevelN163);
-//	m_pAPU->SetChipLevel(SNDCHIP_S5B, pSettings->ChipLevels.iLevelS5B);
-*/
-	// Update blip-buffer filtering 
-	m_pAPU->SetupMixer(pSettings->Sound.iBassFilter, pSettings->Sound.iTrebleFilter,  pSettings->Sound.iTrebleDamping, pSettings->Sound.iMixVolume);
+	{
+		auto config = CAPUConfig(m_pAPU);
+
+		config.SetChipLevel(CHIP_LEVEL_APU1, float(pSettings->ChipLevels.iLevelAPU1 / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_APU2, float(pSettings->ChipLevels.iLevelAPU2 / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_VRC6, float(pSettings->ChipLevels.iLevelVRC6 / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_VRC7, float(pSettings->ChipLevels.iLevelVRC7 / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_MMC5, float(pSettings->ChipLevels.iLevelMMC5 / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_FDS, float(pSettings->ChipLevels.iLevelFDS / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_N163, float(
+			(pSettings->ChipLevels.iLevelN163 + currN163LevelOffset) / 10.0f));
+		config.SetChipLevel(CHIP_LEVEL_S5B, float(pSettings->ChipLevels.iLevelS5B / 10.0f));
+
+		// Update blip-buffer filtering
+		config.SetupMixer(pSettings->Sound.iBassFilter, pSettings->Sound.iTrebleFilter, pSettings->Sound.iTrebleDamping, pSettings->Sound.iMixVolume);
+	}
 
 	m_bAudioClipping = false;
 	m_bBufferUnderrun = false;
@@ -2243,7 +2239,10 @@ void CSoundGen::OnSetChip(WPARAM wParam, LPARAM lParam)
 {
 	int Chip = wParam;
 
-	m_pAPU->SetExternalSound(Chip);
+	{
+		auto config = CAPUConfig(m_pAPU);
+		config.SetExternalSound(Chip);
+	}
 
 	// Enable internal channels after reset
 	m_pAPU->Write(0x4015, 0x0F);


### PR DESCRIPTION
## Make FDS lowpass filter configurable in settings

The FDS lowpass filter cutoff slider is located in the Configuration dialog's new Emulation tab.

The code has to thread the FDS filter cutoff value from CSoundGen reading from its pointer to CSettings, through CAPUConfig::SetupMixer, to CMixer::SetMixing and CMixer::RecomputeMixing, finally into CFDS::UpdateFdsFilter().

## Refactor CAPU reconfiguration into a transaction object

The previous CAPU configuration methods were somewhat hacky (eg. CMixer::ExternalSound() called UpdateMixing() with the same parameters as before, but with different member variables) and depended on the order of method calls, which was confusing, and error-prone in theory (but the existing API usages worked fine in practice, and adding configurable FDS filter would've worked fine).

I replaced the eager update system with CAPUConfig, a "transaction object" that queues up changes and recomputes the necessary set of derived data when destroyed. I find that this approach scales well to more complex scenarios like exotracker's GUI updates, which proved to be unworkable using eager updates.