### PR TITLE
Fix volume levels of N163 and 5B to match previous 0CC/Dn

### DIFF
--- a/Source/APU/Mixer.cpp
+++ b/Source/APU/Mixer.cpp
@@ -160,7 +160,7 @@ float CMixer::GetAttenuation() const
 	return Attenuation;
 }
 
-constexpr int N163_RANGE = 1200;
+constexpr int N163_RANGE = 1600;
 
 void CMixer::RecomputeMixing()
 {
@@ -212,8 +212,8 @@ void CMixer::RecomputeMixing()
 
 	SynthVRC6.volume(Volume * 3.98333f * m_fLevelVRC6, 500);
 	SynthMMC5.volume(Volume * 1.18421f * m_fLevelMMC5, 130);
-	SynthS5B.volume(Volume * m_fLevelS5B, 1600);  // Not checked
 	SynthN163.volume(Volume * 1.1f * m_fLevelN163, N163_RANGE);  // Not checked
+	SynthS5B.volume(Volume * m_fLevelS5B, 1200);  // Not checked
 }
 
 /// CN163::Process() calls CMixer::SetNamcoVolume().


### PR DESCRIPTION
The N163/5B's volume levels were unintentionally changed in #27, which sadly made it into the 0.3.0 release.

When moving chip volume levels from CMixer's declaration to `CMixer::UpdateSettings()`, I swapped their levels by mistake. (This happened because `SynthS5B` and `SynthN163` were listed in opposite orders in the declaration and method.) This resulted in the 5B being too quiet and N163 being too loud, compared to past versions of 0CC/Dn.

This PR fixes their volume levels to match prior program versions. Both the N163 and 5B volume level formulas are probably inaccurate, but at least matching prior versions of FT is better than being inconsistent.