### PR TITLE
Fix broken Open dialog when launching Dn by opening a file

### DIFF
--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -193,13 +193,8 @@ BOOL CFamiTrackerApp::InitInstance()
 		m_pDocManager = new CDocManager0CC { };
 	m_pDocManager->AddDocTemplate(pDocTemplate);
 
-	// Work-around to enable file type registration in windows vista/7
-	if (IsWindowsVistaOrGreater()) {		// // //
-		HKEY HKCU;
-		long res_reg = ::RegOpenKey(HKEY_CURRENT_USER, _T("Software\\Classes"), &HKCU);
-		if(res_reg == ERROR_SUCCESS)
-			RegOverridePredefKey(HKEY_CLASSES_ROOT, HKCU);
-	}
+	// Enable file type registration in Windows Vista and up
+	AfxSetPerUserRegistration(TRUE);
 
 	// Enable DDE Execute open
 	EnableShellOpen();
@@ -220,6 +215,8 @@ BOOL CFamiTrackerApp::InitInstance()
 		AfxRegSetValue(HKEY_CLASSES_ROOT, strTemp, REG_SZ, strOpenCommandLine, lstrlen(strOpenCommandLine) * sizeof(TCHAR));
 	}
 #endif
+
+	AfxSetPerUserRegistration(FALSE);
 
 	// Handle command line export
 	if (cmdInfo.m_bExport) {


### PR DESCRIPTION
On Windows Vista and up, `RegOverridePredefKey` is necessary for Dn's `RegisterShellFileTypes()` to create .0cc file associations without running as admin. Unfortunately that function also screws with the program's view of the registry. When opening a file from the command line, Dn later runs `ProcessShellCommand`, which indirectly calls `SHGetFileInfo` and `SHParseDisplayName`, which queries the registry. With `RegOverridePredefKey` in place, these registry queries load and cache incorrect data, causing file dialogs to see incorrect special folders (like the home directory being called "UsersFiles", and "This PC" disappearing from the sidebar, and sometimes the "Downloads" folder being unclickable).

This commit fixes the bug by replacing `RegOverridePredefKey()` with `AfxSetPerUserRegistration(TRUE)` (discovered in a [2007 forum post](https://social.msdn.microsoft.com/Forums/vstudio/en-US/1f90d106-6cc2-4fd3-a31d-13e742386b5c/calling-cwinappregistershellfiletypes-in-vista?forum=vcgeneral) and having literally 9 Google results). This function only affects MFC `RegisterShellFileTypes()` and doesn't break special folders. Just to be safe, run `AfxSetPerUserRegistration(FALSE)` before calling `ProcessShellCommand` afterwards. It's safe to omit this call (the bug is still fixed), but I prefer avoiding persistent changes to global state.

I tested that .0cc file associations were being created properly using a clean non-admin user account. A build of Dn-FT with `RegOverridePredefKey()` removed was unable to create a .0cc file association. Replacing it with `AfxSetPerUserRegistration(TRUE)` fixed the ability to create per-user file associations. However both programs can *update* the .0cc file association on a user account which already has a per-user .0cc file type/association.

Fixes #74.