### PR TITLE
Prevent ctrl/shift+wheel edit outside edit mode

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -781,11 +781,11 @@ BOOL CFamiTrackerView::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 		InvalidateFrameEditor();		// // //
 	}
 	else if (bControlPressed) {
-		if (!(theApp.IsPlaying() && !IsSelecting() && m_bFollowMode))		// // //
+		if (m_bEditEnable && !(theApp.IsPlaying() && !IsSelecting() && m_bFollowMode))		// // //
 			pAction = new CPActionTranspose {zDelta > 0 ? TRANSPOSE_INC_NOTES : TRANSPOSE_DEC_NOTES};		// // //
 	}
 	else if (bShiftPressed) {
-		if (!(theApp.IsPlaying() && !IsSelecting() && m_bFollowMode))
+		if (m_bEditEnable && !(theApp.IsPlaying() && !IsSelecting() && m_bFollowMode))
 			pAction = new CPActionScrollValues {zDelta > 0 ? 1 : -1};		// // //
 	}
 	else


### PR DESCRIPTION
Although you're not in edit mode, you can still transpose the note by `Ctrl+Wheel`, and change the instrument by `Shift+Wheel`.
This commit fix it.