### PR TITLE
Fix random crash when exporting channels as WAV

### DIFF
--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -112,6 +112,7 @@ CSoundGen::CSoundGen() :
 	m_iGraphBuffer(NULL),
 	m_pDocument(NULL),
 	m_pTrackerView(NULL),
+	m_bRequestRenderStart(false),
 	m_bRendering(false),
 	m_bPlaying(false),
 	m_bHaltRequest(false),
@@ -1815,6 +1816,8 @@ bool CSoundGen::RenderToFile(LPTSTR pFile, render_end_t SongEndType, int SongEnd
 		m_iRenderRowCount = m_iRenderEndParam;
 	}
 
+	ASSERT(!m_bRendering);
+	ASSERT(m_pWaveFile == nullptr);
 	m_pWaveFile = std::make_unique<CWaveFile>();
 	// Unfortunately, destructor doesn't cleanup object. Only CloseFile() does.
 	if (!m_pWaveFile ||
@@ -1822,8 +1825,10 @@ bool CSoundGen::RenderToFile(LPTSTR pFile, render_end_t SongEndType, int SongEnd
 		AfxMessageBox(IDS_FILE_OPEN_ERROR);
 		return false;
 	}
-	else
+	else {
+		m_bRequestRenderStart = true;
 		PostThreadMessage(WM_USER_START_RENDER, 0, 0);
+	}
 
 	return true;
 }
@@ -1865,7 +1870,7 @@ void CSoundGen::GetRenderStat(int &Frame, int &Time, bool &Done, int &FramesToRe
 
 bool CSoundGen::IsRendering() const
 {
-	return m_bRendering;
+	return m_bRequestRenderStart || m_bRendering;
 }
 
 bool CSoundGen::IsBackgroundTask() const
@@ -2215,6 +2220,7 @@ void CSoundGen::OnStartRender(WPARAM wParam, LPARAM lParam)
 {
 	CSingleLock l = Lock();
 	ResetBuffer();
+	m_bRequestRenderStart = false;
 	m_bRequestRenderStop = false;
 	m_bStoppingRender = false;		// // //
 	m_bRendering = true;

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -1798,6 +1798,8 @@ bool CSoundGen::RenderToFile(LPTSTR pFile, render_end_t SongEndType, int SongEnd
 		WaitForStop();
 	}
 
+	CSingleLock l = Lock();
+
 	m_iRenderEndWhen = SongEndType;
 	m_iRenderEndParam = SongEndParam;
 	m_iRenderTrack = Track;
@@ -1831,6 +1833,8 @@ void CSoundGen::StopRendering()
 	// Called from player thread
 	ASSERT(GetCurrentThreadId() == m_nThreadID);
 	ASSERT(m_bRendering);
+
+	CSingleLock l = Lock();
 
 	if (!IsRendering())
 		return;
@@ -2209,6 +2213,7 @@ void CSoundGen::OnResetPlayer(WPARAM wParam, LPARAM lParam)
 
 void CSoundGen::OnStartRender(WPARAM wParam, LPARAM lParam)
 {
+	CSingleLock l = Lock();
 	ResetBuffer();
 	m_bRequestRenderStop = false;
 	m_bStoppingRender = false;		// // //

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -432,4 +432,11 @@ public:
 	afx_msg void OnCloseSound(WPARAM wParam, LPARAM lParam);
 	afx_msg void OnSetChip(WPARAM wParam, LPARAM lParam);
 	afx_msg void OnRemoveDocument(WPARAM wParam, LPARAM lParam);
+
+public:
+	CSingleLock Lock() {
+		auto out = CSingleLock(&m_csAPULock, TRUE);
+		ASSERT(out.IsLocked());
+		return out;
+	}
 };

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -368,6 +368,7 @@ private:
 	machine_t			m_iMachineType;						// // // NTSC/PAL
 
 	// Rendering
+	bool				m_bRequestRenderStart;
 	bool				m_bRendering;
 	bool				m_bRequestRenderStop;
 	bool				m_bStoppingRender;					// // //

--- a/Source/WavProgressDlg.cpp
+++ b/Source/WavProgressDlg.cpp
@@ -100,11 +100,13 @@ void CWavProgressDlg::OnTimer(UINT_PTR nIDEvent)
 	CProgressCtrl *pProgressBar = static_cast<CProgressCtrl*>(GetDlgItem(IDC_PROGRESS_BAR));
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
 
+	CSingleLock l = pSoundGen->Lock();
 	bool Rendering = pSoundGen->IsRendering();
 
 	int Frame, RenderedTime, FramesToRender, RowCount, Row;
 	bool Done;
 	pSoundGen->GetRenderStat(Frame, RenderedTime, Done, FramesToRender, Row, RowCount);
+	l.Unlock();
 
 	if (!Rendering)
 		Row = RowCount;	// Force 100%


### PR DESCRIPTION
Hopefully this code is approximately correct. I've tested it with [`CWavProgressDlg`'s timer](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/blob/ef3abf8a7408002fc899e5046f8b26674a9b18b6/Source/WavProgressDlg.cpp#L88) set to run continuously (switch 200 to 0), and it seems to work without issues.

This code fixes the random crash when exporting multiple channels (due to a data race/race condition), and a theoretical issue that causes WAV files to be skipped entirely if the GUI dialog's progress bar timer fires before the audio thread gets a chance to start rendering (which is unlikely to happen unless the timer is modified to run continuously, as mentioned above).

Fixes #92.