### PR TITLE
Add invalid note indicator

### DIFF
--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -3391,6 +3391,7 @@ void CFamiTrackerDoc::SetMachine(machine_t Machine)
 {
 	ASSERT(Machine == PAL || Machine == NTSC);
 	m_iMachine = Machine;
+	UpdateAllViews(NULL, UPDATE_PATTERN);
 	SetModifiedFlag();
 	SetExceededFlag();		// // //
 }

--- a/Source/InstrumentEditorDPCM.cpp
+++ b/Source/InstrumentEditorDPCM.cpp
@@ -221,6 +221,7 @@ void CInstrumentEditorDPCM::UpdateKey(int Index)
 
 	pTableListCtrl->SetItemText(Index, 1, PitchStr);
 	pTableListCtrl->SetItemText(Index, 2, NameStr);
+	GetDocument()->UpdateAllViews(NULL, UPDATE_PATTERN);	// // //
 }
 
 void CInstrumentEditorDPCM::BuildSampleList()
@@ -256,6 +257,7 @@ void CInstrumentEditorDPCM::BuildSampleList()
 		MakeIntString(MAX_SAMPLE_SPACE / 0x400));
 	
 	SetDlgItemText(IDC_SPACE, Text);
+	GetDocument()->UpdateAllViews(NULL, UPDATE_PATTERN);	// // //
 }
 
 // When saved in NSF, the samples has to be aligned at even 6-bits addresses

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -1471,7 +1471,7 @@ void CPatternEditor::DrawCell(CDC *pDC, int PosX, cursor_column_t Column, int Ch
 						// // // Check valid note
 						const int N163limits[] = { 95, 95, 95, 94, 90, 87, 84, 82 };
 						COLORREF noteCol = pColorInfo->Note;
-						if (((pTrackerChannel->GetID() <= CHANID_TRIANGLE || pTrackerChannel->GetChip() == SNDCHIP_MMC5) && (pNoteData->Note-1+pNoteData->Octave*12 < 9)) ||
+						if (((pTrackerChannel->GetID() <= CHANID_TRIANGLE || pTrackerChannel->GetChip() == SNDCHIP_MMC5) && (pNoteData->Note-1+pNoteData->Octave*12 < 9-m_pDocument->GetMachine())) ||
 							(pTrackerChannel->GetChip() == SNDCHIP_FDS && pNoteData->Note-1+pNoteData->Octave*12 > 92) ||
 							(pTrackerChannel->GetChip() == SNDCHIP_N163 && pNoteData->Note-1+pNoteData->Octave*12 > N163limits[m_pDocument->GetNamcoChannels()-1]))
 							noteCol = RGB(255, 0, 0);


### PR DESCRIPTION
Any notes that are outside of a channel's pitch range are colored red to indicate this.
Also, notes in the DPCM channel with no assigned sample will also be marked as such.