### PR TITLE
Replace DirectSound backend with WASAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,12 @@ include(cmake/exe.cmake)
 
 #builds the .chm file
 if(WIN32)
-	add_custom_command(TARGET ${exe}
-		PRE_BUILD
-		COMMAND cmd /c ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compile-chm.bat
-		COMMAND move Dn-Famitracker.chm ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
-		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-		COMMENT "Generating help file...")
+    add_custom_command(TARGET ${exe}
+        PRE_BUILD
+        COMMAND cmd /c ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compile-chm.bat
+        COMMAND move Dn-Famitracker.chm ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Generating help file...")
 endif()
 
 target_compile_features(${exe} PRIVATE cxx_std_17)
@@ -47,7 +47,7 @@ endif()
 
 # linking
 TARGET_LINK_LIBRARIES(${exe}
-        Dbghelp winmm comctl32 dsound Version htmlhelp)
+        Dbghelp winmm comctl32 Avrt Version htmlhelp)
 
 # Dn-FamiTracker.rc includes res/Dn-FamiTracker.manifest.
 # To prevent manifest linking errors:

--- a/Dn-FamiTracker.rc
+++ b/Dn-FamiTracker.rc
@@ -2860,8 +2860,8 @@ BEGIN
     IDS_WAVE_PROGRESS_FRAME_FORMAT "Frame: %1 (%2 done)"
     IDS_WAVE_PROGRESS_TIME_FORMAT "Time: %1 (%2 done)"
     IDS_WAVE_PROGRESS_ELAPSED_FORMAT "Elapsed time: %1"
-    IDS_DSOUND_ERROR        "DirectX: DirectSound error!"
-    IDS_DSOUND_BUFFER_ERROR "DirectX: DirectSound error: Could not create buffer!"
+    IDS_SOUND_ERROR         "WASAPI error: Could not find sound device!"
+    IDS_SOUND_BUFFER_ERROR  "WASAPI error: Could not open audio stream (likely wrong sampling rate)!"
     IDS_EDIT_MODE           "Changed to edit mode"
     IDS_NORMAL_MODE         "Changed to normal mode"
     IDS_MIDI_MESSAGE_ON_FORMAT 

--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -412,7 +412,7 @@
     <ClCompile Include="Source\ChannelsS5B.cpp" />
     <ClCompile Include="Source\ChannelsVRC6.cpp" />
     <ClCompile Include="Source\ChannelsVRC7.cpp" />
-    <ClCompile Include="Source\DirectSound.cpp" />
+    <ClCompile Include="Source\SoundInterface.cpp" />
     <ClCompile Include="Source\MIDI.cpp" />
     <ClCompile Include="Source\Clipboard.cpp" />
     <ClCompile Include="Source\PatternAction.cpp" />
@@ -681,7 +681,7 @@ makehm /h /a afxhh.h IDW_,HIDW_,0x50000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.
     <ClInclude Include="Source\ChannelsS5B.h" />
     <ClInclude Include="Source\ChannelsVRC6.h" />
     <ClInclude Include="Source\ChannelsVRC7.h" />
-    <ClInclude Include="Source\DirectSound.h" />
+    <ClInclude Include="Source\SoundInterface.h" />
     <ClInclude Include="Source\AboutDlg.h" />
     <ClInclude Include="Source\ChannelsDlg.h" />
     <ClInclude Include="Source\CommentsDlg.h" />

--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -125,7 +125,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;dsound.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>true</DataExecutionPrevention>
@@ -165,7 +165,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;dsound.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <DataExecutionPrevention>true</DataExecutionPrevention>
@@ -206,7 +206,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;dsound.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>
       </Version>
       <AdditionalLibraryDirectories>$(LibraryPath)</AdditionalLibraryDirectories>
@@ -249,7 +249,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;dsound.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>
       </Version>
       <AdditionalLibraryDirectories>$(LibraryPath)</AdditionalLibraryDirectories>

--- a/Dn-FamiTracker.vcxproj.filters
+++ b/Dn-FamiTracker.vcxproj.filters
@@ -504,7 +504,7 @@
     <ClCompile Include="Source\ChannelsVRC7.cpp">
       <Filter>Source Files\Sound Driver\Channels</Filter>
     </ClCompile>
-    <ClCompile Include="Source\DirectSound.cpp">
+    <ClCompile Include="Source\SoundInterface.cpp">
       <Filter>Source Files\Sound Driver\Audio</Filter>
     </ClCompile>
     <ClCompile Include="Source\MIDI.cpp">
@@ -839,7 +839,7 @@
     <ClInclude Include="Source\ChannelsVRC7.h">
       <Filter>Header Files\Sound Driver Headers\Channels Headers</Filter>
     </ClInclude>
-    <ClInclude Include="Source\DirectSound.h">
+    <ClInclude Include="Source\SoundInterface.h">
       <Filter>Header Files\Sound Driver Headers\Audio Headers</Filter>
     </ClInclude>
     <ClInclude Include="Source\AboutDlg.h">

--- a/Source/APU/FDS.cpp
+++ b/Source/APU/FDS.cpp
@@ -58,8 +58,11 @@ void CFDS::UpdateFilter(blip_eq_t eq)
 {
 	m_SynthFDS.treble_eq(eq); // Apply 2A03 global EQ on top of FDS's dedicated lowpass.
 
-	// This line of code was copied from CMixer::AllocateBuffer(),
-	// which does some math in order to calculate the length of the Blip_Buffer.
+	// Blip_Buffer::set_sample_rate(new_rate, msec=250) treats the second msec argument
+	// (or its default value) as the length of the buffer.
+	//
+	// CMixer::AllocateBuffer() calls Blip_Buffer::set_sample_rate(new_rate, msec) on the
+	// global Blip_Buffer, and does some math in order to calculate its length.
 	// What nobody realized is that the value passed in is *always* 125 ms,
 	// modulo rounding error:
 	//
@@ -69,8 +72,8 @@ void CFDS::UpdateFilter(blip_eq_t eq)
 	//
 	// just... wtf.
 	//
-	// We can't access the length of the global Blip_Buffer, so leave the length as default.
-	// The default value of 250 ms is more than enough.
+	// We can't access the length of the global Blip_Buffer, so leave m_BlipFDS's length
+	// as default. The default value of 250 ms is more than enough.
 	m_BlipFDS.set_sample_rate(eq.sample_rate);
 
 	// BlipFDS is used to render FDS.

--- a/Source/ConfigSound.cpp
+++ b/Source/ConfigSound.cpp
@@ -67,7 +67,7 @@ BOOL CConfigSound::OnInitDialog()
 	CComboBox *pSampleRate	= static_cast<CComboBox*>(GetDlgItem(IDC_SAMPLE_RATE));
 	CComboBox *pSampleSize	= static_cast<CComboBox*>(GetDlgItem(IDC_SAMPLE_SIZE));
 	CComboBox *pDevices		= static_cast<CComboBox*>(GetDlgItem(IDC_DEVICES));
-	
+
 	CSliderCtrl *pBufSlider			  = static_cast<CSliderCtrl*>(GetDlgItem(IDC_BUF_LENGTH));
 	CSliderCtrl *pBassSlider		  = static_cast<CSliderCtrl*>(GetDlgItem(IDC_BASS_FREQ));
 	CSliderCtrl *pTrebleSliderFreq	  = static_cast<CSliderCtrl*>(GetDlgItem(IDC_TREBLE_FREQ));

--- a/Source/ConfigSound.cpp
+++ b/Source/ConfigSound.cpp
@@ -29,7 +29,7 @@
 #include "ConfigSound.h"
 #include "SoundGen.h"
 #include "Settings.h"
-#include "DirectSound.h"
+#include "SoundInterface.h"
 
 // CConfigSound dialog
 
@@ -105,11 +105,11 @@ BOOL CConfigSound::OnInitDialog()
 
 	UpdateTexts();
 
-	CDSound *pDSound = theApp.GetSoundGenerator()->GetSoundInterface();
-	const int iCount = pDSound->GetDeviceCount();
+	CSoundInterface *pSoundInterface = theApp.GetSoundGenerator()->GetSoundInterface();
+	const int iCount = pSoundInterface->GetDeviceCount();
 
 	for (int i = 0; i < iCount; ++i)
-		pDevices->AddString(pDSound->GetDeviceName(i));
+		pDevices->AddString(pSoundInterface->GetDeviceName(i));
 
 	pDevices->SetCurSel(pSettings->Sound.iDevice);
 

--- a/Source/ConfigSound.cpp
+++ b/Source/ConfigSound.cpp
@@ -109,7 +109,7 @@ BOOL CConfigSound::OnInitDialog()
 	const int iCount = pSoundInterface->GetDeviceCount();
 
 	for (int i = 0; i < iCount; ++i)
-		pDevices->AddString(pSoundInterface->GetDeviceName(i));
+		pDevices->AddString(pSoundInterface->GetDeviceName(i).c_str());
 
 	pDevices->SetCurSel(pSettings->Sound.iDevice);
 

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -78,6 +78,7 @@ END_MESSAGE_MAP()
 // CFamiTrackerApp construction
 
 CFamiTrackerApp::CFamiTrackerApp() :
+	m_CoInitialized(false),
 	m_bThemeActive(false),
 	m_pMIDI(NULL),
 	m_pAccel(NULL),
@@ -121,6 +122,15 @@ BOOL CFamiTrackerApp::InitInstance()
 
 	if (!AfxOleInit()) {
 		TRACE("OLE initialization failed\n");
+	}
+
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	if (FAILED(hr)) {
+		TRACE("CFamiTrackerApp: Failed to CoInitializeEx COM!\n");
+	}
+	if (!FAILED(hr)) {
+		// Call CoUninitialize() on shutdown.
+		m_CoInitialized = true;
 	}
 
 	// Standard initialization
@@ -335,6 +345,10 @@ int CFamiTrackerApp::ExitInstance()
 #endif
 
 	m_pVersionChecker.reset();		// // //
+
+	if (m_CoInitialized) {
+		CoUninitialize();
+	}
 
 	TRACE("App: End ExitInstance\n");
 

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -254,7 +254,7 @@ BOOL CFamiTrackerApp::InitInstance()
 	m_pMainWnd->DragAcceptFiles();
 	
 	// Initialize the sound interface, also resumes the thread
-	if (!m_pSoundGenerator->InitializeSound(m_pMainWnd->m_hWnd)) {
+	if (!m_pSoundGenerator->InitializeSound()) {
 		// If failed, restore and save default settings
 		m_pSettings->DefaultSettings();
 		m_pSettings->SaveSettings();

--- a/Source/FamiTracker.h
+++ b/Source/FamiTracker.h
@@ -170,6 +170,7 @@ private:
 	CMutex			*m_pInstanceMutex;
 	HANDLE			m_hWndMapFile;
 
+	bool m_CoInitialized;
 	bool			m_bRunning = false;		// // //
 	bool			m_bThemeActive;
 

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -197,6 +197,7 @@ BEGIN_MESSAGE_MAP(CFamiTrackerView, CView)
 	ON_MESSAGE(WM_USER_MIDI_EVENT, OnUserMidiEvent)
 	ON_MESSAGE(WM_USER_PLAYER, OnUserPlayerEvent)
 	ON_MESSAGE(WM_USER_NOTE_EVENT, OnUserNoteEvent)
+	ON_MESSAGE(WM_USER_ERROR, &CFamiTrackerView::OnAudioThreadError)
 	ON_WM_CLOSE()
 	ON_WM_DESTROY()
 	// // //
@@ -590,6 +591,12 @@ LRESULT CFamiTrackerView::OnUserNoteEvent(WPARAM wParam, LPARAM lParam)
 
 	RegisterKeyState(Channel, Note);
 
+	return 0;
+}
+
+LRESULT CFamiTrackerView::OnAudioThreadError(WPARAM wParam, LPARAM lParam)
+{
+	AfxMessageBox((UINT)wParam, (UINT)lParam);
 	return 0;
 }
 

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -409,6 +409,7 @@ public:
 	afx_msg LRESULT OnUserMidiEvent(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnUserPlayerEvent(WPARAM wParam, LPARAM lParam);
 	afx_msg LRESULT OnUserNoteEvent(WPARAM wParam, LPARAM lParam);
+	afx_msg LRESULT OnAudioThreadError(WPARAM wParam, LPARAM lParam);
 	virtual void OnInitialUpdate();
 	virtual DROPEFFECT OnDragEnter(COleDataObject* pDataObject, DWORD dwKeyState, CPoint point);
 	virtual void OnDragLeave();

--- a/Source/FamiTrackerViewMessage.h
+++ b/Source/FamiTrackerViewMessage.h
@@ -33,4 +33,20 @@ enum {
 	WM_USER_MIDI_EVENT,				// There is a new MIDI command	
 	WM_USER_NOTE_EVENT,				// There is a new note command (by player)
 	WM_USER_DUMP_INST,				// // // End of track, add instrument
+	
+	WM_USER_ERROR,  // audio thread error, (nIDPrompt, nType)
+	/*
+	Previously the audio thread would call AfxMessageBox upon errors. The resulting
+	message boxes would often appear under the main window.
+
+	https://forums.codeguru.com/showthread.php?454091-AfxMessageBox-from-a-worker-thread
+	says to never call AfxMessageBox from a non-GUI thread, but instead call PostMessage
+	to an object on the main window. http://flounder.com/workerthreads.htm says it can
+	be a view rather than a CWinApp.
+
+	As a result, the audio thread now calls
+	CFamiTrackerView::PostMessage(WM_USER_ERROR, nIDPrompt, nType), which messages the
+	main thread to call CFamiTrackerView::OnAudioThreadError(), which calls
+	AfxMessageBox(nIDPrompt, nType).
+	*/
 };

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -128,6 +128,7 @@ CSoundGen::CSoundGen() :
 	m_pInstRecorder(new CInstrumentRecorder(this)),		// // //
 	m_bWaveChanged(0),
 	m_iMachineType(NTSC),
+	m_CoInitialized(false),
 	m_bRunning(false),
 	m_hInterruptEvent(NULL),
 	m_bBufferTimeout(false),
@@ -1994,6 +1995,15 @@ BOOL CSoundGen::InitInstance()
 	// Setup the sound player object, called when thread is started
 	//
 
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	if (FAILED(hr)) {
+		TRACE("SoundGen: Failed to CoInitializeEx COM!\n");
+	}
+	if (!FAILED(hr)) {
+		// Call CoUninitialize() on shutdown.
+		m_CoInitialized = true;
+	}
+
 	ASSERT(m_pDocument != NULL);
 	ASSERT(m_pTrackerView != NULL);
 
@@ -2065,6 +2075,10 @@ int CSoundGen::ExitInstance()
 	theApp.RemoveSoundGenerator();
 
 	m_bRunning = false;
+
+	if (m_CoInitialized) {
+		CoUninitialize();
+	}
 
 	return CWinThread::ExitInstance();
 }

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -2030,6 +2030,22 @@ BOOL CSoundGen::InitInstance()
 
 //	SetupChannels();
 
+	// We need to initialize state before playback begins.
+	//
+	// Normally, CSoundStream comes up and the GUI sends a WM_USER_STOP message,
+	// calling CSoundGen::OnStopPlayer() -> CSoundGen::HaltPlayer() which initializes
+	// state.
+	//
+	// However, if CSoundStream fails to initialize (for example due to WASAPI
+	// sampling rate not matching system rate), WM_USER_STOP never arrives
+	// and CSoundGen::HaltPlayer() is never called to initialize state.
+	// Once you fix the sampling rate and properly initialize CSoundStream,
+	// FT crashes in CChannelHandler::GetVibrato() because
+	// CChannelHandler::m_iVibratoDepth is uninitialized.
+	//
+	// To avoid the crash, we need to initialize state on startup.
+	HaltPlayer();
+
 	return TRUE;
 }
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -25,7 +25,7 @@
 //
 // This file takes care of the NES sound playback
 //
-// TODO: 
+// TODO:
 //  - Break out actual player functions to a new class CPlayer
 //  - Create new interface for CFamiTrackerView with thread-safe functions
 //  - Same for CFamiTrackerDoc
@@ -106,7 +106,7 @@ int dither(long size);
 
 // CSoundGen
 
-CSoundGen::CSoundGen() : 
+CSoundGen::CSoundGen() :
 	m_pAPU(NULL),
 	m_pSoundInterface(NULL),
 	m_pSoundStream(NULL),
@@ -383,9 +383,9 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 	if (pDocument != m_pDocument)
 		return;
 	ASSERT(pDocument != NULL);
-	
+
 	SetupVibratoTable(pDocument->GetVibratoStyle());		// // //
-	
+
 	machine_t Machine = pDocument->GetMachine();
 	const double A440_NOTE = 45. - pDocument->GetTuningSemitone() - pDocument->GetTuningCent() / 100.;
 	double clock_ntsc = CAPU::BASE_FREQ_NTSC / 16.0;
@@ -399,7 +399,7 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 		// 2A07
 		Pitch = (clock_pal / Freq) - 0.5;
 		m_iNoteLookupTablePAL[i] = (unsigned int)(Pitch - pDocument->GetDetuneOffset(1, i));		// // //
-		
+
 		// 2A03 / MMC5 / VRC6
 		Pitch = (clock_ntsc / Freq) - 0.5;
 		m_iNoteLookupTableNTSC[i] = (unsigned int)(Pitch - pDocument->GetDetuneOffset(0, i));		// // //
@@ -432,7 +432,7 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 			m_iNoteLookupTableVRC7[i] = (unsigned int)(Pitch + pDocument->GetDetuneOffset(3, i));		// // //
 		}
 	}
-	
+
 	// // // Setup note tables
 	for (int i = 0; i < CHANNELS; ++i) {
 		if (!m_pChannels[i]) continue;
@@ -526,7 +526,7 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 			str.Format("$%04X, ", m_iNoteLookupTableVRC7[i] << 2);
 		period_file.WriteString(str);
 	}
-	
+
 	period_file.WriteString("ft_note_table_vrc7_l: ;; Patch\n");
 	period_file.WriteString("\t.lobytes ft_vrc7_table\n");
 	period_file.WriteString("ft_note_table_vrc7_h:\n");
@@ -545,7 +545,7 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 		if (auto pChan = dynamic_cast<CChannelHandlerN163*>(m_pChannels[i]))
 			pChan->SetChannelCount(pDocument->GetNamcoChannels());
 	}
-	
+
 	m_iSpeedSplitPoint = pDocument->GetSpeedSplitPoint();
 
 	if (currN163LevelOffset != pDocument->GetN163LevelOffset()) {
@@ -613,7 +613,7 @@ void CSoundGen::PreviewSample(const CDSample *pSample, int Offset, int Pitch)		/
 	if (!m_hThread)
 		return;
 
-	// Preview a DPCM sample. If the name of sample is null, 
+	// Preview a DPCM sample. If the name of sample is null,
 	// the sample will be removed after played
 	PostThreadMessage(WM_USER_PREVIEW_SAMPLE, (WPARAM)pSample, MAKELPARAM(Offset, Pitch));
 }
@@ -665,7 +665,7 @@ void CSoundGen::Interrupt() const
 		::SetEvent(m_hInterruptEvent);
 }
 
-bool CSoundGen::GetSoundTimeout() const 
+bool CSoundGen::GetSoundTimeout() const
 {
 	// Read without reset
 	return m_bBufferTimeout;
@@ -996,7 +996,7 @@ unsigned int CSoundGen::GetFrameRate()
 
 void CSoundGen::GenerateVibratoTable(vibrato_t Type)
 {
-	for (int i = 0; i < 16; ++i) {	// depth 
+	for (int i = 0; i < 16; ++i) {	// depth
 		for (int j = 0; j < 16; ++j) {	// phase
 			int value = 0;
 			double angle = (double(j) / 16.0) * (3.1415 / 2.0);
@@ -1015,7 +1015,7 @@ void CSoundGen::GenerateVibratoTable(vibrato_t Type)
 	CStdioFile a("..\\nsf driver\\vibrato.s", CFile::modeWrite | CFile::modeCreate);
 	a.WriteString("; Vibrato table (256 bytes)\n"
 				  "ft_vibrato_table: ;; Patch\n");
-	for (int i = 0; i < 16; i++) {	// depth 
+	for (int i = 0; i < 16; i++) {	// depth
 		a.WriteString("\t.byte ");
 		for (int j = 0; j < 16; j++) {	// phase
 			CString b;
@@ -1186,7 +1186,7 @@ static CString GetStateString(const stChannelState &State)
 	else
 		log.AppendFormat(_T("%02X"), State.Instrument);
 	log.AppendFormat(_T("        Vol.: %X        Active effects:"), State.Volume >= MAX_VOLUME ? 0xF : State.Volume);
-	
+
 	CString effStr = _T("");
 
 	const effect_t SLIDE_EFFECT = State.Effect[EF_ARPEGGIO] >= 0 ? EF_ARPEGGIO :
@@ -1295,7 +1295,7 @@ void CSoundGen::HaltPlayer()
 	m_bDoHalt = false;		// // //
 
 	MakeSilent();
-	
+
 	m_pAPU->ClearSample();		// // //
 /*
 	for (int i = 0; i < CHANNELS; ++i) {
@@ -1377,7 +1377,7 @@ void CSoundGen::HaltPlayer()
 			*reinterpret_cast<int*>(Header + 0x78) = 0x0110;
 		}
 	}
-	
+
 	vgm.Write(Header, 256);
 	vgm.Close();
 #endif
@@ -1394,7 +1394,7 @@ void CSoundGen::ResetAPU()
 	// Enable all channels
 	m_pAPU->Write(0x4015, 0x0F);
 	m_pAPU->Write(0x4017, 0x00);
-	
+
 	// // // for VGM
 	WriteRegister(0x4015, 0x0F);
 	WriteRegister(0x4017, 0x00);
@@ -1418,7 +1418,7 @@ void CSoundGen::AddCyclesUnlessEndOfFrame(int Count)
 }
 
 uint8_t CSoundGen::GetReg(int Chip, int Reg) const
-{ 
+{
 	return m_pAPU->GetReg(Chip, Reg);
 }
 
@@ -1470,7 +1470,7 @@ void CSoundGen::ResetTempo()
 	m_iSpeed = m_pDocument->GetSongSpeed(m_iPlayTrack);
 	m_iTempo = m_pDocument->GetSongTempo(m_iPlayTrack);
 	m_iLastHighlight = m_pDocument->GetHighlight().First;		// // //
-	
+
 	m_iTempoAccum = 0;
 
 	if (m_pDocument->GetSongGroove(m_iPlayTrack) && m_pDocument->GetGroove(m_iSpeed) != NULL) {		// // //
@@ -1553,7 +1553,7 @@ void CSoundGen::RunFrame()
 	m_pTrackerView->PlayerTick();
 
 	if (IsPlaying()) {
-		
+
 		++m_iPlayTicks;
 
 		if (m_bRendering) {
@@ -1717,7 +1717,7 @@ int CSoundGen::GetChannelVolume(int Channel) const
 }
 
 void CSoundGen::PlayNote(int Channel, stChanNote *NoteData, int EffColumns)
-{	
+{
 	if (!NoteData)
 		return;
 
@@ -1756,7 +1756,7 @@ void CSoundGen::EvaluateGlobalEffects(stChanNote *NoteData, int EffColumns)
 				}
 				SetupSpeed();
 				break;
-				
+
 			// Oxx: Sets groove to xx
 			// currently does not support starting at arbitrary index of a groove
 			case EF_GROOVE:		// // //
@@ -1904,7 +1904,7 @@ void CSoundGen::PlaySample(const CDSample *pSample, int Offset, int Pitch)
 	m_pAPU->Write(0x4013, Length);			// length
 	m_pAPU->Write(0x4015, 0x0F);
 	m_pAPU->Write(0x4015, 0x1F);			// fire sample
-	
+
 	// Auto-delete samples with no name
 	if (*pSample->GetName() == 0)
 		m_pPreviewSample = pSample;
@@ -1945,7 +1945,7 @@ BOOL CSoundGen::InitInstance()
 
 	// First check if thread creation should be cancelled
 	// This will occur when no sound object is available
-	
+
 	if (m_pSoundInterface == NULL)
 		return FALSE;
 
@@ -2082,7 +2082,7 @@ void CSoundGen::PlayChannelNotes()
 		int Index = m_pTrackerChannels[i]->GetID();
 		int Channel = m_pDocument->GetChannelIndex(m_pTrackerChannels[Index]->GetID());
 		if (Channel == -1) continue;
-		
+
 		// Run auto-arpeggio, if enabled
 		int Arpeggio = m_pTrackerView->GetAutoArpeggio(Channel);
 		if (Arpeggio > 0) {
@@ -2142,7 +2142,7 @@ void CSoundGen::UpdateAPU()
 	// Copy wave changed flag
 	m_bInternalWaveChanged = m_bWaveChanged;
 	m_bWaveChanged = false;
-	
+
 	{
 		auto l = DeferLock();
 		if (l.try_lock()) {
@@ -2396,7 +2396,7 @@ void CSoundGen::PlayerSkipTo(int Row)
 {
 	const int Frames = m_pDocument->GetFrameCount(m_iPlayTrack);
 	const int Rows = m_pDocument->GetPatternLength(m_iPlayTrack);
-	
+
 	m_bFramePlayed[m_iPlayFrame] = true;
 
 	if (++m_iPlayFrame >= Frames)
@@ -2406,7 +2406,7 @@ void CSoundGen::PlayerSkipTo(int Row)
 
 	if (m_iPlayRow >= Rows)
 		m_iPlayRow = Rows - 1;
-	
+
 	++m_iFramesPlayed;
 	++m_iRowsPlayed;		// // //
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -723,7 +723,7 @@ bool CSoundGen::ResetAudioDevice()
 
 	// Reinitialize sound interface
 	if (!m_pSoundInterface->SetupDevice(Device)) {
-		AfxMessageBox(IDS_SOUND_ERROR, MB_ICONERROR);
+		m_pTrackerView->PostMessage(WM_USER_ERROR, IDS_SOUND_ERROR, MB_ICONERROR);
 		return false;
 	}
 
@@ -738,7 +738,7 @@ bool CSoundGen::ResetAudioDevice()
 
 	// Channel failed
 	if (m_pSoundStream == NULL) {
-		AfxMessageBox(IDS_SOUND_BUFFER_ERROR, MB_ICONERROR);
+		m_pTrackerView->PostMessage(WM_USER_ERROR, IDS_SOUND_BUFFER_ERROR, MB_ICONERROR);
 		return false;
 	}
 
@@ -1886,7 +1886,7 @@ bool CSoundGen::RenderToFile(LPTSTR pFile, render_end_t SongEndType, int SongEnd
 	// Unfortunately, destructor doesn't cleanup object. Only CloseFile() does.
 	if (!m_pWaveFile ||
 		!m_pWaveFile->OpenFile(pFile, theApp.GetSettings()->Sound.iSampleRate, theApp.GetSettings()->Sound.iSampleSize, 1)) {
-		AfxMessageBox(IDS_FILE_OPEN_ERROR);
+		m_pTrackerView->PostMessage(WM_USER_ERROR, IDS_FILE_OPEN_ERROR);
 		return false;
 	}
 	else {

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -1023,7 +1023,7 @@ bool CSoundGen::PlayBuffer(unsigned int framesToWrite, unsigned int bytesToWrite
 		m_csVisualizerWndLock.Lock();
 
 		if (m_pVisualizerWnd)
-			m_pVisualizerWnd->FlushSamples(m_iGraphBuffer, framesToWrite);
+			m_pVisualizerWnd->FlushSamples(gsl::span(m_iGraphBuffer, framesToWrite));
 
 		m_csVisualizerWndLock.Unlock();
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -983,9 +983,8 @@ void CSoundGen::FillBuffer(int16_t const * pBuffer, uint32_t Size)
 	}
 
 	/*
-	Write the entire remaining buffer to WASAPI. In practice, this eliminates
-	stuttering at low latencies (below 30ms or so), though I'm not sure why.
-	How do we know it's legal to do so?
+	Write the entire remaining buffer to WASAPI. This is not necessary to prevent
+	stuttering, but it's harmless to keep. How do we know it's legal to do so?
 
 	Before the loop, we call TryWaitForWritable(), which calls WaitForReady() before
 	updating framesWritable.

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -846,7 +846,7 @@ bool CSoundGen::TryWaitForWritable(uint32_t& framesWritable, uint32_t& bytesWrit
 	// slow down export), and redesigning to avoid this is hard.
 	while (true) {
 		WaitResult result = m_pSoundStream->WaitForReady(AUDIO_TIMEOUT);
-		TRACE("WaitResult %d\n", result);
+		// TRACE("WaitResult %d\n", result);
 		switch (result) {
 		case WaitResult::Ready:
 			goto endWhile;

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -82,8 +82,8 @@ class CFamiTrackerDoc;
 class CInstrument;		// // //
 class CSequence;		// // //
 class CAPU;
-class CDSound;
-class CDSoundChannel;
+class CSoundInterface;
+class CSoundStream;
 class CWaveFile;		// // //
 class CVisualizerWnd;
 class CDSample;
@@ -124,7 +124,7 @@ public:
 	// Sound
 	bool		InitializeSound(HWND hWnd);
 	void		FlushBuffer(int16_t const * pBuffer, uint32_t Size);
-	CDSound		*GetSoundInterface() const { return m_pDSound; };
+	CSoundInterface		*GetSoundInterface() const { return m_pSoundInterface; };
 
 	void		Interrupt() const;
 	bool		GetSoundTimeout() const;
@@ -299,8 +299,8 @@ private:
 	CFamiTrackerView	*m_pTrackerView;
 
 	// Sound
-	CDSound				*m_pDSound;
-	CDSoundChannel		*m_pDSoundChannel;
+	CSoundInterface				*m_pSoundInterface;
+	CSoundStream		*m_pSoundStream;
 	CVisualizerWnd		*m_pVisualizerWnd;
 	CAPU				*m_pAPU;
 	int currN163LevelOffset;

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -316,6 +316,7 @@ private:
 
 	const CDSample		*m_pPreviewSample;
 
+	bool m_CoInitialized;
 	bool				m_bRunning;
 
 	// Thread synchronization

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -40,7 +40,7 @@ const int VIBRATO_LENGTH = 256;
 const int TREMOLO_LENGTH = 256;
 
 // Custom messages
-enum { 
+enum {
 	WM_USER_SILENT_ALL = WM_USER + 1,
 	WM_USER_LOAD_SETTINGS,
 	WM_USER_PLAY,
@@ -66,9 +66,9 @@ enum play_mode_t {
 	MODE_PLAY_MARKER,		// // // 050B (row marker, aka "bookmark")
 };
 
-enum render_end_t { 
-	SONG_TIME_LIMIT, 
-	SONG_LOOP_LIMIT 
+enum render_end_t {
+	SONG_TIME_LIMIT,
+	SONG_LOOP_LIMIT
 };
 
 class stChanNote;		// // //
@@ -110,7 +110,7 @@ private:		// // //
 	//
 public:
 
-	// One time initialization 
+	// One time initialization
 	void		AssignDocument(CFamiTrackerDoc *pDoc);
 	void		AssignView(CFamiTrackerView *pView);
 	void		RemoveDocument();
@@ -146,7 +146,7 @@ public:
 	int			 ReadPeriodTable(int Index, int Table) const;		// // //
 
 	// Player interface
-	void		 StartPlayer(play_mode_t Mode, int Track);	
+	void		 StartPlayer(play_mode_t Mode, int Track);
 	void		 StopPlayer();
 	void		 ResetPlayer(int Track);
 	void		 LoadSettings();
@@ -176,7 +176,7 @@ public:
 	bool		 RenderToFile(LPTSTR pFile, render_end_t SongEndType, int SongEndParam, int Track);
 	void		 StopRendering();
 	void		 GetRenderStat(int &Frame, int &Time, bool &Done, int &FramesToRender, int &Row, int &RowCount) const;
-	bool		 IsRendering() const;	
+	bool		 IsRendering() const;
 	bool		 IsBackgroundTask() const;
 
 	// Sample previewing
@@ -240,7 +240,7 @@ public:
 
 	int GetDefaultInstrument() const;
 
-	// 
+	//
 	// Private functions
 	//
 private:
@@ -272,7 +272,7 @@ private:
 
 	// Misc
 	void		PlaySample(const CDSample *pSample, int Offset, int Pitch);
-	
+
 	// Player
 	void		ReadPatternRow();
 	void		PlayerStepRow();
@@ -330,11 +330,11 @@ private:
 	bool				m_bBufferUnderrun;
 	bool				m_bAudioClipping;
 	int					m_iClipCounter;
-	
+
 // Tracker playing variables
 private:
 	unsigned int		m_iTempo;							// Tempo and speed
-	unsigned int		m_iSpeed;							
+	unsigned int		m_iSpeed;
 	int					m_iGrooveIndex;						// // // Current groove
 	unsigned int		m_iGroovePosition;					// // // Groove position
 	int					m_iTempoAccum;						// Used for speed calculation

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -33,6 +33,7 @@
 #include "Common.h"
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 
@@ -122,7 +123,14 @@ public:
 	void		LoadMachineSettings();		// // // 050B
 
 	// Sound
-	bool		InitializeSound(HWND hWnd);
+	bool		InitializeSound();
+
+	/// Waits for room to write audio to the output buffer.
+	///
+	/// If ready to write audio, writes room available to parameters and returns true.
+	/// If waiting for buffer failed (due to GUI interruption or audio timeout),
+	/// returns false.
+	bool TryWaitForWritable(uint32_t& framesWritable, uint32_t& bytesWritable);
 	void		FlushBuffer(int16_t const * pBuffer, uint32_t Size);
 	CSoundInterface		*GetSoundInterface() const { return m_pSoundInterface; };
 
@@ -254,7 +262,8 @@ private:
 	void		CloseAudioDevice();
 	void		CloseAudio();
 	template<class T, int SHIFT> void FillBuffer(int16_t const * pBuffer, uint32_t Size);
-	bool		PlayBuffer();
+	unsigned int GetBufferFramesWritable() const;
+	bool		PlayBuffer(unsigned int framesToWrite, unsigned int bytesToWrite);
 
 	// Player
 	void		UpdateChannels();

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -63,10 +63,10 @@ CSoundInterface::~CSoundInterface()
 }
 
 bool CSoundInterface::SetupDevice(int iDevice)
-{	
+{
 	if (iDevice > (int)m_iDevices)
 		iDevice = 0;
-	
+
 	if (m_lpDirectSound) {
 		m_lpDirectSound->Release();
 		m_lpDirectSound = NULL;
@@ -131,7 +131,7 @@ void CSoundInterface::EnumerateDevices()
 		ClearEnumeration();
 
 	DirectSoundEnumerate(DSEnumCallback, NULL);
-	
+
 #ifdef _DEBUG
 	// Add an invalid device for debugging reasons
 	GUID g;
@@ -188,14 +188,14 @@ CSoundStream *CSoundInterface::OpenChannel(int SampleRate, int SampleSize, int C
 	// Adjust buffer length in case a buffer would end up in half samples
 	while ((SampleRate * BufferLength / (Blocks * 1000) != (double)SampleRate * BufferLength / (Blocks * 1000)))
 		++BufferLength;
- 
+
 	CSoundStream *pChannel = new CSoundStream();
 
 	HANDLE hBufferEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
 	int SoundBufferSize = CalculateBufferLength(BufferLength, SampleRate, SampleSize, Channels);
 	int BlockSize = SoundBufferSize / Blocks;
-	
+
 	pChannel->m_iBufferLength		= BufferLength;			// in ms
 	pChannel->m_iSoundBufferSize	= SoundBufferSize;		// in bytes
 	pChannel->m_iBlockSize			= BlockSize;			// in bytes
@@ -246,7 +246,7 @@ CSoundStream *CSoundInterface::OpenChannel(int SampleRate, int SampleSize, int C
 	}
 
 	pChannel->ClearBuffer();
-	
+
 	return pChannel;
 }
 
@@ -309,7 +309,7 @@ bool CSoundStream::ClearBuffer()
 
 	if (FAILED(m_lpDirectSoundBuffer->Lock(0, m_iSoundBufferSize, (void**)&pAudioPtr1, &AudioBytes1, (void**)&pAudioPtr2, &AudioBytes2, 0)))
 		return false;
-	
+
 	if (m_iSampleSize == 8) {
 		memset(pAudioPtr1, 0x80, AudioBytes1);
 		if (pAudioPtr2)
@@ -343,7 +343,7 @@ bool CSoundStream::WriteBuffer(char const * pBuffer, unsigned int Samples)
 	int	  Block = m_iCurrentWriteBlock;
 
 	ASSERT(Samples == m_iBlockSize);
-	
+
 	if (FAILED(m_lpDirectSoundBuffer->Lock(Block * m_iBlockSize, m_iBlockSize, (void**)&pAudioPtr1, &AudioBytes1, (void**)&pAudioPtr2, &AudioBytes2, 0)))
 		return false;
 

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -45,23 +45,11 @@
 // Instance members
 
 CSoundInterface::CSoundInterface(HANDLE hInterrupt) :
-	m_hInterrupt(hInterrupt),
-	m_CoInitialized(false)
+	m_hInterrupt(hInterrupt)
 {
 	// Based off:
 	// https://github.com/wareya/AudioLibraryRosettaStone/blob/master/wasapi.cpp#L52
 	// https://github.com/thestk/rtaudio/blob/e9b1d0262a5e75e09c510eb9c5825daf86884d29/RtAudio.cpp#L4320
-
-	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
-	// Ignore error RPC_E_CHANGED_MODE and proceed.
-	if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
-		// COM setup failed, don't try initializing audio.
-		return;
-	}
-	if (!FAILED(hr)) {
-		// Call CoUninitialize() on shutdown.
-		m_CoInitialized = true;
-	}
 
 	// Instantiate device enumerator
 	if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL,
@@ -74,9 +62,6 @@ CSoundInterface::CSoundInterface(HANDLE hInterrupt) :
 
 CSoundInterface::~CSoundInterface()
 {
-	if (m_CoInitialized) {
-		CoUninitialize();
-	}
 }
 
 void CSoundInterface::EnumerateDevices()

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -532,7 +532,7 @@ unsigned int CSoundStream::BufferFramesWritable() const {
 	if (FAILED(hr)) return 0;
 
 	UINT32 numFramesAvailable = m_bufferFrameCount - numFramesPadding;
-	TRACE("%d frames available of %d\n", numFramesAvailable, m_bufferFrameCount);
+	// TRACE("%d frames available of %d\n", numFramesAvailable, m_bufferFrameCount);
 	return numFramesAvailable;
 }
 

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -23,63 +23,190 @@
 */
 
 //
-// DirectSound Interface
+// Sound Interface
 //
 
 #include "stdafx.h"
 #include <cstdio>
+#include <utility>  // std::move
 #include "Common.h"
 #include "SoundInterface.h"
 #include "../resource.h"
 
-// The single CSoundInterface object
-CSoundInterface *CSoundInterface::pThisObject = NULL;
-
-// Class members
-
-BOOL CALLBACK CSoundInterface::DSEnumCallback(LPGUID lpGuid, LPCTSTR lpcstrDescription, LPCTSTR lpcstrModule, LPVOID lpContext)
-{
-	return pThisObject->EnumerateCallback(lpGuid, lpcstrDescription, lpcstrModule, lpContext);
-}
+// WASAPI headers
+#define WIN32_LEAN_AND_MEAN
+#include <synchapi.h>  // CreateEventW
+#include <initguid.h>  // Possibly needed for GUIDs?
+#include <avrt.h>  // AvSetMmThreadCharacteristicsW
+#include <mmdeviceapi.h>  // IMMDeviceEnumerator
+#include <audioclient.h>  // IAudioClient
+#include <Functiondiscoverykeys_devpkey.h>  // PKEY_Device_FriendlyName
 
 // Instance members
 
-CSoundInterface::CSoundInterface(HWND hWnd, HANDLE hNotification) :
-	m_iDevices(0),
-	m_lpDirectSound(NULL),
-	m_hWndTarget(hWnd),
-	m_hNotificationHandle(hNotification)
+CSoundInterface::CSoundInterface(HANDLE hInterrupt) :
+	m_hInterrupt(hInterrupt),
+	m_CoInitialized(false)
 {
-	ASSERT(pThisObject == NULL);
-	pThisObject = this;
+	// Based off:
+	// https://github.com/wareya/AudioLibraryRosettaStone/blob/master/wasapi.cpp#L52
+	// https://github.com/thestk/rtaudio/blob/e9b1d0262a5e75e09c510eb9c5825daf86884d29/RtAudio.cpp#L4320
+
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+	// Ignore error RPC_E_CHANGED_MODE and proceed.
+	if (FAILED(hr) && hr != RPC_E_CHANGED_MODE) {
+		// COM setup failed, don't try initializing audio.
+		return;
+	}
+	if (!FAILED(hr)) {
+		// Call CoUninitialize() on shutdown.
+		m_CoInitialized = true;
+	}
+
+	// Instantiate device enumerator
+	if (FAILED(CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL,
+		CLSCTX_ALL, __uuidof(IMMDeviceEnumerator),
+		(void**)m_maybeDeviceEnumerator.GetAddressOf()))
+	) {
+		return;
+	}
 }
 
 CSoundInterface::~CSoundInterface()
 {
-	for (int i = 0; i < (int)m_iDevices; ++i) {
-		delete [] m_pcDevice[i];
-		delete [] m_pGUIDs[i];
+	if (m_CoInitialized) {
+		CoUninitialize();
+	}
+}
+
+void CSoundInterface::EnumerateDevices()
+{
+	// It is probably safe to construct m_maybeDeviceEnumerator: *IMMDeviceEnumerator
+	// in the constructor on the main thread, Send it to the audio thread, and access
+	// it from methods called there: https://github.com/RustAudio/cpal/pull/597
+
+	// Populate device list.
+	if (!m_maybeDeviceEnumerator) {
+		return;
+	}
+
+	// https://github.com/thestk/rtaudio/blob/e9b1d0262a5e75e09c510eb9c5825daf86884d29/RtAudio.cpp#L4379-L4390
+	HRESULT hr = m_maybeDeviceEnumerator->EnumAudioEndpoints(
+		eRender, DEVICE_STATE_ACTIVE, m_maybeRawDeviceList.ReleaseAndGetAddressOf()
+	);
+	if (FAILED(hr)) return;
+}
+
+void CSoundInterface::ClearEnumeration()
+{
+	// Clear device list.
+	m_maybeRawDeviceList.Reset();
+}
+
+unsigned int CSoundInterface::GetDeviceCount() const
+{
+	if (!m_maybeRawDeviceList) {
+		return 0;
+	}
+	UINT RawDeviceCount;
+	HRESULT hr = m_maybeRawDeviceList->GetCount(&RawDeviceCount);
+	if (FAILED(hr)) {
+		return 0;
+	}
+
+	// External device 0 is "Default Device".
+	return RawDeviceCount + 1;
+}
+
+// https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/author-coclasses#add-helper-types-and-functions
+struct PropVariant : PROPVARIANT
+{
+	PropVariant() noexcept : PROPVARIANT{}
+	{
+	}
+
+	~PropVariant() noexcept
+	{
+		clear();
+	}
+
+	void clear() noexcept
+	{
+		// Don't check the return value. It should be fine, I hope...
+		PropVariantClear(this);
+	}
+};
+
+static conv::tstring GetDevicePtrName(IMMDevice * pDevice) {
+	// https://github.com/thestk/rtaudio/blob/e9b1d0262a5e75e09c510eb9c5825daf86884d29/RtAudio.cpp#L4522-L4530
+	ComPtr<IPropertyStore> pDevicePropStore;
+	auto hr = pDevice->OpenPropertyStore(STGM_READ, pDevicePropStore.GetAddressOf());
+	if (FAILED(hr)) return _T("Error: opening device properties");
+
+	PropVariant deviceNameProp;
+	hr = pDevicePropStore->GetValue(PKEY_Device_FriendlyName, &deviceNameProp);
+	if (FAILED(hr)) return _T("Error: getting device name");
+
+	return conv::to_t(deviceNameProp.pwszVal);
+}
+
+conv::tstring CSoundInterface::GetDeviceName(unsigned int iDevice) const
+{
+	ASSERT(iDevice < GetDeviceCount());
+
+	ComPtr<IMMDevice> pDevice;
+
+	if (iDevice == 0) {
+		if (!m_maybeDeviceEnumerator) {
+			return _T("Error: device enumerator missing");
+		}
+
+		// https://github.com/thestk/rtaudio/blob/e9b1d0262a5e75e09c510eb9c5825daf86884d29/RtAudio.cpp#L4493-L4513
+		auto hr = m_maybeDeviceEnumerator->GetDefaultAudioEndpoint(
+			eRender, eConsole, pDevice.GetAddressOf()
+		);
+		if (FAILED(hr)) return _T("Error: getting default device");
+
+		auto name = GetDevicePtrName(pDevice.Get());
+		return _T("Default Device (") + name + _T(")");
+	} else {
+		UINT rawDevice = iDevice - 1;
+
+		if (!m_maybeRawDeviceList) {
+			return _T("Error: device list missing");
+		}
+		auto hr = m_maybeRawDeviceList->Item(rawDevice, pDevice.GetAddressOf());
+		if (FAILED(hr)) return _T("Error: getting device");
+
+		return GetDevicePtrName(pDevice.Get());
 	}
 }
 
 bool CSoundInterface::SetupDevice(int iDevice)
 {
-	if (iDevice > (int)m_iDevices)
+	// Replace out-of-bounds devices with default device.
+	if (iDevice >= 1 && (unsigned)(iDevice - 1) >= GetDeviceCount()) {
 		iDevice = 0;
-
-	if (m_lpDirectSound) {
-		m_lpDirectSound->Release();
-		m_lpDirectSound = NULL;
 	}
 
-	if (FAILED(DirectSoundCreate((LPCGUID)m_pGUIDs[iDevice], &m_lpDirectSound, NULL))) {
-		m_lpDirectSound = NULL;
+	m_maybeDevice.Reset();
+
+	if (!m_maybeDeviceEnumerator) {
 		return false;
 	}
-
-	if (FAILED(m_lpDirectSound->SetCooperativeLevel(m_hWndTarget, DSSCL_PRIORITY))) {
-		m_lpDirectSound = NULL;
-		return false;
+	if (iDevice == 0) {
+		auto hr = m_maybeDeviceEnumerator->GetDefaultAudioEndpoint(
+			eRender, eConsole, m_maybeDevice.GetAddressOf()
+		);
+		if (FAILED(hr)) return false;
+	}
+	else {
+		UINT rawDevice = iDevice - 1;
+		if (!m_maybeRawDeviceList) {
+			return false;
+		}
+		auto hr = m_maybeRawDeviceList->Item(rawDevice, m_maybeDevice.GetAddressOf());
+		if (FAILED(hr)) return false;
 	}
 
 	return true;
@@ -87,85 +214,12 @@ bool CSoundInterface::SetupDevice(int iDevice)
 
 void CSoundInterface::CloseDevice()
 {
-	if (!m_lpDirectSound)
-		return;
-
-	m_lpDirectSound->Release();
-	m_lpDirectSound = NULL;
-
-	if (m_iDevices != 0)
-		ClearEnumeration();
+	m_maybeDevice.Reset();
+	m_maybeRawDeviceList.Reset();
 }
 
-void CSoundInterface::ClearEnumeration()
-{
-	for (unsigned i = 0; i < m_iDevices; ++i) {
-		delete [] m_pcDevice[i];
-		if (m_pGUIDs[i] != NULL)
-			delete m_pGUIDs[i];
-	}
-
-	m_iDevices = 0;
-}
-
-BOOL CSoundInterface::EnumerateCallback(LPGUID lpGuid, LPCTSTR lpcstrDescription, LPCTSTR lpcstrModule, LPVOID lpContext)
-{
-	m_pcDevice[m_iDevices] = new TCHAR[_tcslen(lpcstrDescription) + 1];
-	_tcscpy((TCHAR*)m_pcDevice[m_iDevices], lpcstrDescription);
-
-	if (lpGuid != NULL) {
-		m_pGUIDs[m_iDevices] = new GUID;
-		memcpy(m_pGUIDs[m_iDevices], lpGuid, sizeof(GUID));
-	}
-	else
-		m_pGUIDs[m_iDevices] = NULL;
-
-	++m_iDevices;
-
-	return TRUE;
-}
-
-void CSoundInterface::EnumerateDevices()
-{
-	if (m_iDevices != 0)
-		ClearEnumeration();
-
-	DirectSoundEnumerate(DSEnumCallback, NULL);
-
-#ifdef _DEBUG
-	// Add an invalid device for debugging reasons
-	GUID g;
-	g.Data1 = 1;
-	g.Data2 = 2;
-	g.Data3 = 3;
-	for (int i = 0; i < 8; ++i)
-		g.Data4[i] = i;
-	EnumerateCallback(&g, _T("Invalid device"), NULL, NULL);
-#endif
-}
-
-unsigned int CSoundInterface::GetDeviceCount() const
-{
-	return m_iDevices;
-}
-
-LPCTSTR CSoundInterface::GetDeviceName(unsigned int iDevice) const
-{
-	ASSERT(iDevice < m_iDevices);
-	return m_pcDevice[iDevice];
-}
-
-int CSoundInterface::MatchDeviceID(LPCTSTR Name) const
-{
-	for (unsigned int i = 0; i < m_iDevices; ++i) {
-		if (!_tcscmp(Name, m_pcDevice[i]))
-			return i;
-	}
-
-	return 0;
-}
-
-int CSoundInterface::CalculateBufferLength(int BufferLen, int Samplerate, int Samplesize, int Channels) const
+// static method, helper function
+int CSoundInterface::CalculateBufferLength(int BufferLen, int Samplerate, int Samplesize, int Channels)
 {
 	// Calculate size of the buffer, in bytes
 	return ((Samplerate * BufferLen) / 1000) * (Samplesize / 8) * Channels;
@@ -173,234 +227,355 @@ int CSoundInterface::CalculateBufferLength(int BufferLen, int Samplerate, int Sa
 
 CSoundStream *CSoundInterface::OpenChannel(int SampleRate, int SampleSize, int Channels, int BufferLength, int Blocks)
 {
-	// Open a new secondary buffer
+	// Based off https://docs.microsoft.com/en-us/windows/win32/coreaudio/exclusive-mode-streams
+	if (!m_maybeDevice) {
+		return nullptr;
+	}
+	ComPtr<IAudioClient> pAudioClient;
+	auto hr = m_maybeDevice->Activate(
+		__uuidof(IAudioClient), CLSCTX_ALL, NULL, (void**)pAudioClient.GetAddressOf()
+	);
+	if (FAILED(hr)) return nullptr;
+
+	const int InputChannels = Channels;
+
+	auto create_wave_format = [&]() {
+		// Can't use designated initializers since we're not in C++20 mode.
+		WAVEFORMATEX format{};
+
+		// https://docs.microsoft.com/en-us/windows/win32/api/mmeapi/ns-mmeapi-waveformatex#members
+		format.wFormatTag = WAVE_FORMAT_PCM;
+		format.nChannels = (WORD)Channels;
+		format.nSamplesPerSec = (DWORD)SampleRate;
+		format.wBitsPerSample = (WORD)SampleSize;
+
+		// If wFormatTag is WAVE_FORMAT_PCM or WAVE_FORMAT_EXTENSIBLE, nBlockAlign must be equal to
+		// the product of nChannels and wBitsPerSample divided by 8 (bits per byte).
+		format.nBlockAlign = (WORD)(format.nChannels * format.wBitsPerSample / 8);
+
+		// If wFormatTag is WAVE_FORMAT_PCM, nAvgBytesPerSec should be equal to the product of
+		// nSamplesPerSec and nBlockAlign.
+		format.nAvgBytesPerSec = (DWORD)(format.nSamplesPerSec * format.nBlockAlign);
+
+		// Size, in bytes, of extra format information appended to the end of the WAVEFORMATEX
+		// structure.
+		format.cbSize = 0;
+
+		return format;
+	};
+	WAVEFORMATEX format = create_wave_format();
+
+	// Ensure that chosen audio format is supported.
+	WAVEFORMATEX* pClosestMatch{};
+	hr = pAudioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, &format, &pClosestMatch);
+	if (Channels == 1 && (hr == S_FALSE || hr == AUDCLNT_E_UNSUPPORTED_FORMAT)) {
+		CoTaskMemFree(pClosestMatch);
+		pClosestMatch = nullptr;
+
+		// Try again in stereo. We will upmix input mono to stereo.
+		Channels = 2;
+		format = create_wave_format();
+		hr = pAudioClient->IsFormatSupported(AUDCLNT_SHAREMODE_SHARED, &format, &pClosestMatch);
+	}
+
+	// So far we don't need to handle audio format fallback, since Windows 7/10 and
+	// Wine all support int16 audio.
+	if (hr != S_OK) {
+		CoTaskMemFree(pClosestMatch);
+		return nullptr;
+	}
+
+	// Convert BufferLength (ms) to REFERENCE_TIME (100ns).
+	REFERENCE_TIME bufferLengthTime = (LONGLONG)BufferLength * 10'000;
+
+	// Shared-mode WASAPI (excluding IAudioClient3::InitializeSharedAudioStream())
+	// creates one buffer of length bufferLengthTime, and lends out random portions
+	// to be written by the program. So don't divide buffer length by 2.
+
+	// Open stream.
+	// The actual buffer size is bufferLengthTime or (on my machine) 22 ms, whichever is
+	// greater. It is legal to call IAudioClient::Initialize(hnsBufferDuration=0),
+	// causing WASAPI to pick a buffer size automatically
+	// (https://docs.microsoft.com/en-us/windows/win32/api/audioclient/nf-audioclient-iaudioclient-initialize#:~:text=shared-mode%20stream%20that%20uses%20event-driven%20buffering).
+	// Passing in too-short sizes like 1ms automatically clamps up to 22ms on Windows 10
+	// and Wine, but hangs on Windows 7.
+	hr = pAudioClient->Initialize(
+		AUDCLNT_SHAREMODE_SHARED,
+		AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+		bufferLengthTime,
+		0,  // periodicity must be 0 for shared streams
+		&format,
+		nullptr);  // We ignore GUID.
+	if (FAILED(hr)) return nullptr;
+
+	// Setup buffer event.
+	auto bufferEvent = HandlePtr(CreateEventW(nullptr, FALSE, FALSE, nullptr));
+	hr = pAudioClient->SetEventHandle(bufferEvent.get());
+	if (FAILED(hr)) return nullptr;
+
+	// Get the actual size of buffer.
+	UINT32 bufferFrameCount;
+	hr = pAudioClient->GetBufferSize(&bufferFrameCount);
+	if (FAILED(hr)) return nullptr;
+
+	// Open stream's buffer writing interface.
+	ComPtr<IAudioRenderClient> pAudioRenderClient;
+	hr = pAudioClient->GetService(
+		__uuidof(IAudioRenderClient), (void**)pAudioRenderClient.GetAddressOf()
+	);
+	if (FAILED(hr)) return nullptr;
+
+	// We want to generate one buffer of audio from CSoundGen before starting IAudioClient.
+	// This is easiest if CSoundStream calls CSoundGen to generate audio, but instead
+	// CSoundGen pushes/waits on CSoundStream. So instead we return a stopped stream,
+	// return immediately from the first call to CSoundStream::WaitForReady(),
+	// and start the stream on the *second* CSoundStream::WaitForReady() call.
 	//
+	// ~~what if CSoundGen and CSoundStream were coroutines~~
 
-	DSBPOSITIONNOTIFY	dspn[MAX_BLOCKS];
-	WAVEFORMATEX		wfx;
-	DSBUFFERDESC		dsbd;
-
-	ASSERT(Blocks > 1);
-
-	if (!m_lpDirectSound)
-		return NULL;
-
-	// Adjust buffer length in case a buffer would end up in half samples
-	while ((SampleRate * BufferLength / (Blocks * 1000) != (double)SampleRate * BufferLength / (Blocks * 1000)))
-		++BufferLength;
-
-	CSoundStream *pChannel = new CSoundStream();
-
-	HANDLE hBufferEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
-
-	int SoundBufferSize = CalculateBufferLength(BufferLength, SampleRate, SampleSize, Channels);
-	int BlockSize = SoundBufferSize / Blocks;
-
-	pChannel->m_iBufferLength		= BufferLength;			// in ms
-	pChannel->m_iSoundBufferSize	= SoundBufferSize;		// in bytes
-	pChannel->m_iBlockSize			= BlockSize;			// in bytes
-	pChannel->m_iBlocks				= Blocks;
-	pChannel->m_iSampleSize			= SampleSize;
-	pChannel->m_iSampleRate			= SampleRate;
-	pChannel->m_iChannels			= Channels;
-
-	pChannel->m_iCurrentWriteBlock	= 0;
-	pChannel->m_hWndTarget			= m_hWndTarget;
-	pChannel->m_hEventList[0]		= m_hNotificationHandle;
-	pChannel->m_hEventList[1]		= hBufferEvent;
-
-	memset(&wfx, 0x00, sizeof(WAVEFORMATEX));
-	wfx.cbSize				= sizeof(WAVEFORMATEX);
-	wfx.nChannels			= Channels;
-	wfx.nSamplesPerSec		= SampleRate;
-	wfx.wBitsPerSample		= SampleSize;
-	wfx.nBlockAlign			= wfx.nChannels * (wfx.wBitsPerSample / 8);
-	wfx.nAvgBytesPerSec		= wfx.nSamplesPerSec * wfx.nBlockAlign;
-	wfx.wFormatTag			= WAVE_FORMAT_PCM;
-
-	memset(&dsbd, 0x00, sizeof(DSBUFFERDESC));
-	dsbd.dwSize			= sizeof(DSBUFFERDESC);
-	dsbd.dwBufferBytes	= SoundBufferSize;
-	dsbd.dwFlags		= DSBCAPS_LOCSOFTWARE | DSBCAPS_GLOBALFOCUS | DSBCAPS_CTRLPOSITIONNOTIFY | DSBCAPS_GETCURRENTPOSITION2;
-	dsbd.lpwfxFormat	= &wfx;
-
-	if (FAILED(m_lpDirectSound->CreateSoundBuffer(&dsbd, &pChannel->m_lpDirectSoundBuffer, NULL))) {
-		delete pChannel;
-		return NULL;
-	}
-
-	// Setup notifications
-	for (int i = 0; i < Blocks; ++i) {
-		dspn[i].dwOffset = i * BlockSize;
-		dspn[i].hEventNotify = hBufferEvent;
-	}
-
-	if (FAILED(pChannel->m_lpDirectSoundBuffer->QueryInterface(IID_IDirectSoundNotify, (void**)&pChannel->m_lpDirectSoundNotify))) {
-		delete pChannel;
-		return NULL;
-	}
-
-	if (FAILED(pChannel->m_lpDirectSoundNotify->SetNotificationPositions(Blocks, dspn))) {
-		delete pChannel;
-		return NULL;
-	}
-
-	pChannel->ClearBuffer();
-
-	return pChannel;
+	return new CSoundStream(
+		std::move(pAudioClient),
+		std::move(pAudioRenderClient),
+		m_hInterrupt,
+		std::move(bufferEvent),
+		SampleRate,
+		bufferFrameCount,
+		SampleSize / 8,  // bytesPerSample
+		InputChannels,
+		Channels);
 }
 
-void CSoundInterface::CloseChannel(CSoundStream *pChannel)
+void CSoundInterface::CloseChannel(CSoundStream *pSoundStream)
 {
-	if (pChannel == NULL)
+	if (pSoundStream == NULL)
 		return;
 
-	pChannel->m_lpDirectSoundBuffer->Release();
-	pChannel->m_lpDirectSoundNotify->Release();
-
-	delete pChannel;
+	delete pSoundStream;
 }
 
 // CSoundStream
 
-CSoundStream::CSoundStream()
+CSoundStream::CSoundStream(
+	ComPtr<IAudioClient> pAudioClient,
+	ComPtr<IAudioRenderClient> pAudioRenderClient,
+	HANDLE hInterrupt,
+	HandlePtr bufferEvent,
+	unsigned int iSampleRate,
+	unsigned int bufferFrameCount,
+	unsigned int bytesPerSample,
+	unsigned int inputChannels,
+	unsigned int outputChannels)
+:
+	m_bufferEvent(std::move(bufferEvent)),
+	m_pAudioClient(std::move(pAudioClient)),
+	m_pAudioRenderClient(std::move(pAudioRenderClient)),
+	m_state(StreamState::Stopped),
+	m_hInterrupt(hInterrupt),
+	m_hTask(nullptr),
+	m_iSampleRate(iSampleRate),
+	m_bufferFrameCount(bufferFrameCount),
+	m_bytesPerSample(bytesPerSample),
+	m_inputChannels(inputChannels),
+	m_outputChannels(outputChannels)
 {
-	m_iCurrentWriteBlock = 0;
-
-	m_hEventList[0] = NULL;
-	m_hEventList[1] = NULL;
-	m_hWndTarget = NULL;
 }
 
 CSoundStream::~CSoundStream()
 {
-	// Kill buffer event
-	if (m_hEventList[1])
-		CloseHandle(m_hEventList[1]);
+	if (m_hTask) {
+		// AvRevertMmThreadCharacteristics must be called on the same thread as
+		// AvSetMmMaxThreadCharacteristics. This is currently the case, but still
+		// makes me uneasy.
+		AvRevertMmThreadCharacteristics(m_hTask);
+	}
 }
 
-bool CSoundStream::Play() const
+bool CSoundStream::Play()
 {
-	// Begin playback of buffer
-	return FAILED(m_lpDirectSoundBuffer->Play(NULL, NULL, DSBPLAY_LOOPING)) ? false : true;
+	// "To avoid start-up glitches with rendering streams, clients should not call Start
+	// until the audio engine has been initially loaded with data by calling the
+	// IAudioRenderClient::GetBuffer and IAudioRenderClient::ReleaseBuffer methods
+	// on the rendering interface."
+
+	auto hr = m_pAudioClient->Start();
+	if (FAILED(hr)) return false;
+
+	m_state = StreamState::Started;
+
+	// Called on the audio thread.
+	// Ask MMCSS to temporarily boost the thread priority to reduce glitches
+	// while the low-latency stream plays.
+	DWORD taskIndex = 0;
+	if (m_hTask == nullptr) {
+		m_hTask = AvSetMmThreadCharacteristicsW(L"Pro Audio", &taskIndex);
+		TRACE("AvSetMmThreadCharacteristicsW success: %d", m_hTask != 0);
+	}
+
+	return true;
 }
 
-bool CSoundStream::Stop() const
+bool CSoundStream::Stop()
 {
-	// Stop playback
-	return FAILED(m_lpDirectSoundBuffer->Stop()) ? false : true;
-}
+	// Only called by CSoundGen::CloseAudioDevice(), before deleting CSoundStream.
+	// Exact behavior is unimportant.
+	auto hr = m_pAudioClient->Stop();
+	if (FAILED(hr)) return false;
 
-bool CSoundStream::IsPlaying() const
-{
-	DWORD Status;
-	m_lpDirectSoundBuffer->GetStatus(&Status);
-	return ((Status & DSBSTATUS_PLAYING) == DSBSTATUS_PLAYING);
+	m_state = StreamState::Stopped;
+
+	// Called on the audio thread.
+	if (m_hTask) {
+		// I could check the return value (failed = FALSE) and return it...
+		// but I don't want CSoundStream::ClearBuffer() -> CSoundStream::Stop() to fail
+		// if m_pAudioClient->Stop() succeeds but AvRevertMmThreadCharacteristics fails.
+		AvRevertMmThreadCharacteristics(m_hTask);
+		m_hTask = nullptr;
+	}
+
+	return true;
 }
 
 bool CSoundStream::ClearBuffer()
 {
-	LPVOID pAudioPtr1, pAudioPtr2;
-	DWORD AudioBytes1, AudioBytes2;
+	// This function is only called when starting or stopping WAV export:
+	// CSoundGen::OnStartRender()/StopRendering() -> CSoundGen::ResetBuffer() ->
+	// CSoundStream::ClearBuffer().
+	//
+	// I'm not sure if it's even necessary to stop the output stream during
+	// WAV export, though it avoids underruns (if we actually reported underruns
+	// properly).
 
-	if (IsPlaying())
+	if (m_state == StreamState::Started)
 		if (!Stop())
 			return false;
 
-	if (FAILED(m_lpDirectSoundBuffer->Lock(0, m_iSoundBufferSize, (void**)&pAudioPtr1, &AudioBytes1, (void**)&pAudioPtr2, &AudioBytes2, 0)))
-		return false;
-
-	if (m_iSampleSize == 8) {
-		memset(pAudioPtr1, 0x80, AudioBytes1);
-		if (pAudioPtr2)
-			memset(pAudioPtr2, 0x80, AudioBytes2);
-	}
-	else {
-		memset(pAudioPtr1, 0x00, AudioBytes1);
-		if (pAudioPtr2)
-			memset(pAudioPtr2, 0x00, AudioBytes2);
-	}
-
-	if (FAILED(m_lpDirectSoundBuffer->Unlock((void*)pAudioPtr1, AudioBytes1, (void*)pAudioPtr2, AudioBytes2)))
-		return false;
-
-	m_lpDirectSoundBuffer->SetCurrentPosition(0);
-	m_iCurrentWriteBlock = 0;
+	auto hr = m_pAudioClient->Reset();
+	if (FAILED(hr)) return false;
 
 	return true;
 }
 
-bool CSoundStream::WriteBuffer(char const * pBuffer, unsigned int Samples)
+// Buffering
+
+uint32_t CSoundStream::PubBytesToFrames(uint32_t Bytes) const
 {
-	// Fill sound buffer
-	//
-	// Buffer	- Pointer to a buffer with samples
-	// Samples	- Number of samples, in bytes
-	//
-
-	LPVOID pAudioPtr1, pAudioPtr2;
-	DWORD AudioBytes1, AudioBytes2;
-	int	  Block = m_iCurrentWriteBlock;
-
-	ASSERT(Samples == m_iBlockSize);
-
-	if (FAILED(m_lpDirectSoundBuffer->Lock(Block * m_iBlockSize, m_iBlockSize, (void**)&pAudioPtr1, &AudioBytes1, (void**)&pAudioPtr2, &AudioBytes2, 0)))
-		return false;
-
-	// Copy "pBuffer head" to "pAudioPtr1 circular buffer".
-	memcpy(pAudioPtr1, pBuffer, AudioBytes1);
-
-	// Copy "pBuffer tail" to "pAudioPtr2 circular buffer head".
-	if (pAudioPtr2)
-		memcpy(pAudioPtr2, pBuffer + AudioBytes1, AudioBytes2);
-
-	if (FAILED(m_lpDirectSoundBuffer->Unlock((void*)pAudioPtr1, AudioBytes1, (void*)pAudioPtr2, AudioBytes2)))
-		return false;
-
-	AdvanceWritePointer();
-
-	return true;
+	return Bytes / m_bytesPerSample / m_inputChannels;
 }
 
-buffer_event_t CSoundStream::WaitForSyncEvent(DWORD dwTimeout) const
+uint32_t CSoundStream::FramesToPubBytes(uint32_t Frames) const
 {
-	// Wait for a DirectSound event
-	if (!IsPlaying()) {
-		if (!Play())
-			return BUFFER_NONE;
+	return Frames * m_bytesPerSample * m_inputChannels;
+}
+
+uint32_t CSoundStream::TotalBufferSizeFrames() const {
+	return m_bufferFrameCount;
+}
+
+uint32_t CSoundStream::TotalBufferSizeBytes() const {
+	return FramesToPubBytes(m_bufferFrameCount);
+}
+
+// Steady-state
+
+WaitResult CSoundStream::WaitForReady(DWORD dwTimeout)
+{
+	switch (m_state) {
+	case StreamState::Stopped:
+		// The first time CSoundGen waits to write audio, don't start stream playback.
+		// Instead return and let CSoundGen write audio. (At this point,
+		// CSoundStream::BufferFramesWritable() returns the full buffer size.)
+		m_state = StreamState::ReadyToStart;
+		return WaitResult::Ready;
+
+	case StreamState::ReadyToStart:
+		// The second time CSoundGen waits to write audio, start the playback stream,
+		// then let CSoundGen write audio.
+		if (!Play()) {
+			return WaitResult::InternalError;
+		}
+		// If CSoundStream::Play() succeeds (returns true), it sets m_state =
+		// StreamState::Started.
+		break;
+
+	case StreamState::Started:
+		// Otherwise wait for room to write audio, like normal.
+		break;
 	}
+	// TODO we can get marginally less latency by having CSoundGen call
+	// CSoundStream::WaitForReady before generating audio, rather than before
+	// converting/buffering it.
+
+	HANDLE waitEvents[2] = { m_hInterrupt, m_bufferEvent.get() };
 
 	// Wait for events
-	switch (::WaitForMultipleObjects(2, m_hEventList, FALSE, dwTimeout)) {
-		case WAIT_OBJECT_0:			// External event
-			return BUFFER_CUSTOM_EVENT;
-		case WAIT_OBJECT_0 + 1:		// DirectSound buffer
-			return (GetWritableBlock() == m_iCurrentWriteBlock) ? BUFFER_OUT_OF_SYNC : BUFFER_IN_SYNC;
-		case WAIT_TIMEOUT:			// Timeout
-			return BUFFER_TIMEOUT;
+	switch (WaitForMultipleObjects(2, waitEvents, FALSE, dwTimeout)) {
+	case WAIT_OBJECT_0:  // hInterrupt: interrupted by GUI
+		return WaitResult::Interrupted;
+
+	case WAIT_OBJECT_0 + 1:  // m_bufferEvent: WASAPI buffer ready to write
+		// I don't know of any way to detect playback buffer underruns in WASAPI.
+		// https://stackoverflow.com/q/32112562 has no answer, and
+		// https://github.com/mackron/miniaudio/issues/81 couldn't figure it out either.
+		return false ? WaitResult::OutOfSync : WaitResult::Ready;
+
+	case WAIT_TIMEOUT:  // Timeout
+		return WaitResult::Timeout;
+
+	default:  // Error
+		return WaitResult::InternalError;
 	}
-
-	// Error
-	return BUFFER_NONE;
 }
 
-int CSoundStream::GetPlayBlock() const
-{
-	// Return the block where the play pos is
-	DWORD PlayPos, WritePos;
-	m_lpDirectSoundBuffer->GetCurrentPosition(&PlayPos, &WritePos);
-	return (PlayPos / m_iBlockSize);
+unsigned int CSoundStream::BufferFramesWritable() const {
+	UINT32 numFramesPadding;
+	auto hr = m_pAudioClient->GetCurrentPadding(&numFramesPadding);
+	if (FAILED(hr)) return 0;
+
+	UINT32 numFramesAvailable = m_bufferFrameCount - numFramesPadding;
+	TRACE("%d frames available of %d\n", numFramesAvailable, m_bufferFrameCount);
+	return numFramesAvailable;
 }
 
-int CSoundStream::GetWritableBlock() const
-{
-	// Return the block where the write pos is
-	DWORD PlayPos, WritePos;
-	m_lpDirectSoundBuffer->GetCurrentPosition(&PlayPos, &WritePos);
-	return (WritePos / m_iBlockSize);
+uint32_t CSoundStream::BufferBytesWritable() const {
+	return FramesToPubBytes(BufferFramesWritable());
 }
 
-void CSoundStream::AdvanceWritePointer()
+bool CSoundStream::WriteBuffer(char const * pSrcBuffer, unsigned int Bytes)
 {
-	m_iCurrentWriteBlock = (m_iCurrentWriteBlock + 1) % m_iBlocks;
+	// Bytes comes from CSoundStream::BufferBytesWritable().
+	unsigned int frames = PubBytesToFrames(Bytes);
+
+	BYTE* pOutData = nullptr;
+	auto hr = m_pAudioRenderClient->GetBuffer(frames, &pOutData);
+	if (FAILED(hr)) return false;
+
+	if (m_outputChannels == 2 && m_inputChannels == 1) {
+		// Upmix mono to stereo.
+		ASSERT(m_bytesPerSample == 1 || m_bytesPerSample == 2);
+		switch (m_bytesPerSample) {
+		case 1: {
+			// feeling fancy, might remove __restrict later
+			auto src8 = (int8_t const* __restrict)pSrcBuffer;
+			auto dst8 = (int8_t * __restrict)pOutData;
+			for (size_t i = 0; i < frames; i++) {
+				dst8[2 * i] = dst8[2 * i + 1] = src8[i];
+			}
+			break;
+		}
+		case 2: {
+			auto src16 = (int16_t const* __restrict)pSrcBuffer;
+			auto dst16 = (int16_t * __restrict)pOutData;
+			for (size_t i = 0; i < frames; i++) {
+				dst16[2 * i] = dst16[2 * i + 1] = src16[i];
+			}
+			break;
+		}
+		}
+	} else {
+		memcpy(pOutData, pSrcBuffer, Bytes);
+	}
+	hr = m_pAudioRenderClient->ReleaseBuffer(frames, 0);
+	if (FAILED(hr)) return false;
+
+	return true;
 }

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -180,7 +180,6 @@ public:
 private:
 	/// Owned by CSoundGen, borrowed by CSoundInterface.
 	HANDLE m_hInterrupt;
-	bool m_CoInitialized;
 
 	// For enumeration
 	ComPtr<IMMDeviceEnumerator> m_maybeDeviceEnumerator;

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -22,8 +22,8 @@
 ** must bear this legend.
 */
 
-#ifndef DSOUND_H
-#define DSOUND_H
+#ifndef SOUNDINTERFACE_H
+#define SOUNDINTERFACE_H
 
 #include <mmsystem.h>
 #include <InitGuid.h>
@@ -32,20 +32,20 @@
 // Return values from WaitForDirectSoundEvent()
 enum buffer_event_t {
 	BUFFER_NONE = 0,
-	BUFFER_CUSTOM_EVENT = 1, 
-	BUFFER_TIMEOUT, 
-	BUFFER_IN_SYNC, 
+	BUFFER_CUSTOM_EVENT = 1,
+	BUFFER_TIMEOUT,
+	BUFFER_IN_SYNC,
 	BUFFER_OUT_OF_SYNC
 };
 
 // DirectSound channel
-class CDSoundChannel 
+class CSoundStream
 {
-	friend class CDSound;
+	friend class CSoundInterface;
 
 public:
-	CDSoundChannel();
-	~CDSoundChannel();
+	CSoundStream();
+	~CSoundStream();
 
 	bool Play() const;
 	bool Stop() const;
@@ -65,7 +65,7 @@ public:
 
 private:
 	int GetPlayBlock() const;
-	
+
 	/*!
 	https://docs.microsoft.com/en-us/previous-versions/windows/desktop/ee418062(v%3Dvs.85)
 	The write cursor is the point in the buffer ahead of which it is safe to write data to the buffer.
@@ -99,17 +99,17 @@ private:
 };
 
 // DirectSound
-class CDSound 
+class CSoundInterface
 {
 public:
-	CDSound(HWND hWnd, HANDLE hNotification);
-	~CDSound();
+	CSoundInterface(HWND hWnd, HANDLE hNotification);
+	~CSoundInterface();
 
 	bool			SetupDevice(int iDevice);
 	void			CloseDevice();
 
-	CDSoundChannel	*OpenChannel(int SampleRate, int SampleSize, int Channels, int BufferLength, int Blocks);
-	void			CloseChannel(CDSoundChannel *pChannel);
+	CSoundStream	*OpenChannel(int SampleRate, int SampleSize, int Channels, int BufferLength, int Blocks);
+	void			CloseChannel(CSoundStream *pChannel);
 
 	int				CalculateBufferLength(int BufferLen, int Samplerate, int Samplesize, int Channels) const;
 
@@ -129,7 +129,7 @@ public:
 
 protected:
 	static BOOL CALLBACK DSEnumCallback(LPGUID lpGuid, LPCTSTR lpcstrDescription, LPCTSTR lpcstrModule, LPVOID lpContext);
-	static CDSound *pThisObject;
+	static CSoundInterface *pThisObject;
 
 private:
 	HWND			m_hWndTarget;
@@ -142,4 +142,4 @@ private:
 	GUID			*m_pGUIDs[MAX_DEVICES];
 };
 
-#endif /* DSOUND_H */
+#endif /* SOUNDINTERFACE_H */

--- a/Source/VisualizerBase.cpp
+++ b/Source/VisualizerBase.cpp
@@ -38,10 +38,12 @@ void CVisualizerBase::Create(int Width, int Height)
 	m_pBlitBuffer = std::make_unique<COLORREF[]>(Width * Height);		// // //
 }
 
-void CVisualizerBase::SetSampleData(short *pSamples, unsigned int iCount)
-{
-	m_pSamples = pSamples;
-	m_iSampleCount = iCount;
+bool CVisualizerBase::SetScopeData(short const* iSamples, unsigned int iCount) {
+	return false;
+}
+
+bool CVisualizerBase::SetSpectrumData(short const* iSamples, unsigned int iCount) {
+	return false;
 }
 
 void CVisualizerBase::Display(CDC *pDC, bool bPaintMsg) {		// // //

--- a/Source/VisualizerBase.h
+++ b/Source/VisualizerBase.h
@@ -36,8 +36,13 @@ public:
 	virtual void Create(int Width, int Height);
 	// Set rate of samples
 	virtual void SetSampleRate(int SampleRate) = 0;
-	// Set new sample data
-	virtual void SetSampleData(short *iSamples, unsigned int iCount);
+
+	// Set new sample data (block-aligned)
+	virtual bool SetScopeData(short const* iSamples, unsigned int iCount);
+
+	// Set new sample data (latest)
+	virtual bool SetSpectrumData(short const* iSamples, unsigned int iCount);
+
 	// Render an image from the sample data
 	virtual void Draw() = 0;
 	// Display the image
@@ -51,5 +56,5 @@ protected:
 	int m_iHeight = 0;
 
 	unsigned int m_iSampleCount = 0;
-	short *m_pSamples = nullptr;
+	short const* m_pSamples = nullptr;
 };

--- a/Source/VisualizerScope.h
+++ b/Source/VisualizerScope.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "VisualizerBase.h"		// // //
+#include <cstdint>
 
 // CVisualizerScope, scope style visualizer
 
@@ -37,15 +38,16 @@ public:
 
 	void Create(int Width, int Height) override;
 	void SetSampleRate(int SampleRate) override;
+	bool SetScopeData(short const* iSamples, unsigned int iCount) override;
 	void Draw() override;
 	void Display(CDC *pDC, bool bPaintMsg) override;
+	size_t NeededSamples() const;
 
 private:
 	void RenderBuffer();
 	void ClearBackground();
 
 private:
-	int	 m_iWindowBufPtr;
 	short *m_pWindowBuf;
 	bool m_bBlur;
 

--- a/Source/VisualizerSpectrum.cpp
+++ b/Source/VisualizerSpectrum.cpp
@@ -53,38 +53,20 @@ void CVisualizerSpectrum::SetSampleRate(int SampleRate)
 	m_iFillPos = 0;
 }
 
-void CVisualizerSpectrum::Transform(short *pSamples, unsigned int Count)
+void CVisualizerSpectrum::Transform(short const* pSamples, unsigned int Count)
 {
 	fft_buffer_.CopyIn(pSamples, Count);
 	fft_buffer_.Transform();
 }
 
-void CVisualizerSpectrum::SetSampleData(short *pSamples, unsigned int iCount)
+bool CVisualizerSpectrum::SetSpectrumData(short const* pSamples, unsigned int iCount)
 {
-	CVisualizerBase::SetSampleData(pSamples, iCount);
+	m_pSamples = pSamples;
+	m_iSampleCount = iCount;
+	ASSERT(m_iSampleCount == FFT_POINTS);
 
 	Transform(pSamples, iCount);
-	/*
-	int offset = 0;
-
-	if (m_iFillPos > 0) {
-		const int size = std::min((int)iCount, FFT_POINTS - m_iFillPos);
-		std::copy_n(pSamples, size, m_pSampleBuffer.begin() + m_iFillPos);
-		Transform(m_pSampleBuffer.data(), FFT_POINTS);
-		offset += size;
-		iCount -= size;
-	}
-
-	while (iCount >= FFT_POINTS) {
-		Transform(pSamples + offset, FFT_POINTS);
-		offset += FFT_POINTS;
-		iCount -= FFT_POINTS;
-	}
-
-	// Copy rest
-	std::copy_n(pSamples + offset, iCount, m_pSampleBuffer.begin());
-	m_iFillPos = iCount;
-	*/
+	return true;
 }
 
 void CVisualizerSpectrum::Draw()
@@ -100,13 +82,13 @@ void CVisualizerSpectrum::Draw()
 
 	for (int i = 0; i < m_iWidth / m_iBarSize; i++) {		// // //
 		int iStep = int(Pos + 0.5f);
-		
+
 		float level = 0;
 		int steps = (iStep - LastStep) + 1;
 		for (int j = 0; j < steps; ++j)
 			level += float(fft_buffer_.GetIntensity(LastStep + j)) / SCALING;
 		level /= steps;
-		
+
 		// linear -> db
 		level = (20 * std::log10(level));// *0.8f;
 
@@ -138,8 +120,8 @@ void CVisualizerSpectrum::Draw()
 					Color = DIM(Color, 50);
 				m_pBlitBuffer[(m_iHeight - 1 - y) * m_iWidth + i * m_iBarSize + x + OFFSET] = y < level ? Color : BG_COLOR;
 			}
-		}	
-		
+		}
+
 		LastStep = iStep;
 		Pos += Step;
 	}

--- a/Source/VisualizerSpectrum.h
+++ b/Source/VisualizerSpectrum.h
@@ -41,11 +41,11 @@ public:
 
 	void Create(int Width, int Height) override;
 	void SetSampleRate(int SampleRate) override;
-	void SetSampleData(short *iSamples, unsigned int iCount) override;
+	bool SetSpectrumData(short const* pSamples, unsigned int iCount) override;
 	void Draw() override;
 
 protected:
-	void Transform(short *pSamples, unsigned int Count);
+	void Transform(short const* pSamples, unsigned int Count);
 
 private:
 	static const COLORREF BG_COLOR = 0;

--- a/Source/VisualizerWnd.cpp
+++ b/Source/VisualizerWnd.cpp
@@ -113,6 +113,10 @@ void CVisualizerWnd::FlushSamples(short *pSamples, int Count)
 	if (!m_bThreadRunning)
 		return;
 
+	// TODO don't replace buffer contents, but push to a ring buffer with two pages
+	// each large enough to compute a spectrum without zero-padding.
+	// Or alternatively call CVisualizerWnd::FlushSamples() with a fixed size, independently
+	// of CSoundStream::WriteBuffer().
 	if (Count != m_iBufferSize) {
 		m_csBuffer.Lock();
 		SAFE_RELEASE_ARRAY(m_pBuffer1);

--- a/Source/VisualizerWnd.h
+++ b/Source/VisualizerWnd.h
@@ -41,7 +41,7 @@ class CVisualizerScope;
 // CVisualizerWnd
 
 /// https://github.com/nyanpasu64/spectro2/blob/master/flip-cell/src/lib.rs
-class TripleBuffer {
+class alignas(64) TripleBuffer {
 	// Constants
 	static constexpr uint8_t INIT_WRITE = 0;
 	static constexpr uint8_t INIT_SHARED = 1;
@@ -53,8 +53,8 @@ class TripleBuffer {
 	// [3] box[...] short
 	std::unique_ptr<short[]> pBuffers[3];
 
-	// box atomic u8
-	std::unique_ptr<std::atomic<uint8_t>> pShared;
+	// atomic u8
+	alignas(64) std::atomic<uint8_t> shared;
 
 	friend class Reader;
 	friend class Writer;

--- a/Source/stdafx.h
+++ b/Source/stdafx.h
@@ -47,7 +47,7 @@
 
 #ifndef _WIN32_WINNT		// Allow use of features specific to Windows NT 4 or later.
 #define _WIN32_WINNT 0x0501		// Change this to the appropriate value to target Windows 98 and Windows 2000 or later.
-#endif						
+#endif
 
 #ifndef _WIN32_WINDOWS		// Allow use of features specific to Windows 98 or later.
 #define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.

--- a/Source/stdafx.h
+++ b/Source/stdafx.h
@@ -41,20 +41,20 @@
 
 // Modify the following defines if you have to target a platform prior to the ones specified below.
 // Refer to MSDN for the latest info on corresponding values for different platforms.
-#ifndef WINVER				// Allow use of features specific to Windows 95 and Windows NT 4 or later.
-#define WINVER 0x0501		// Change this to the appropriate value to target Windows 98 and Windows 2000 or later.
+#ifndef WINVER
+#define WINVER _WIN32_WINNT_VISTA
 #endif
 
-#ifndef _WIN32_WINNT		// Allow use of features specific to Windows NT 4 or later.
-#define _WIN32_WINNT 0x0501		// Change this to the appropriate value to target Windows 98 and Windows 2000 or later.
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT _WIN32_WINNT_VISTA
 #endif
 
-#ifndef _WIN32_WINDOWS		// Allow use of features specific to Windows 98 or later.
-#define _WIN32_WINDOWS 0x0410 // Change this to the appropriate value to target Windows Me or later.
+#ifndef _WIN32_WINDOWS
+#define _WIN32_WINDOWS _WIN32_WINNT_VISTA
 #endif
 
-#ifndef _WIN32_IE			// Allow use of features specific to IE 4.0 or later.
-#define _WIN32_IE 0x0600	// Change this to the appropriate value to target IE 5.0 or later.
+#ifndef _WIN32_IE
+#define _WIN32_IE _WIN32_WINNT_VISTA
 #endif
 
 #define _ATL_CSTRING_EXPLICIT_CONSTRUCTORS	// some CString constructors will be explicit

--- a/Source/str_conv/str_conv.hpp
+++ b/Source/str_conv/str_conv.hpp
@@ -104,11 +104,11 @@ auto to_wide(T&& str) {
 
 // defined by nyanpasu64:
 
-typedef std::basic_string<TCHAR> _tstring;
+typedef std::basic_string<TCHAR> tstring;
 
 template <typename T>
 auto to_t(T&& str) {
-	return details::to_utf_string<_tstring>(std::forward<T>(str));
+	return details::to_utf_string<tstring>(std::forward<T>(str));
 }
 
 } // namespace conv

--- a/cmake/exe.cmake
+++ b/cmake/exe.cmake
@@ -96,7 +96,7 @@ add_executable(${exe}
         Source/DetuneDlg.cpp
         Source/DetuneTable.cpp
         Source/DialogReBar.cpp
-        Source/DirectSound.cpp
+        Source/SoundInterface.cpp
         Source/DocumentFile.cpp
         Source/DocumentWrapper.cpp
         Source/DPI.cpp

--- a/resource.h
+++ b/resource.h
@@ -197,8 +197,8 @@
 #define IDS_WAVE_PROGRESS_TIME_FORMAT   310
 #define IDS_WAVE_PROGRESS_ELAPSED_FORMAT 311
 #define IDR_EXPORT_TEST_REPORT          311
-#define IDS_DSOUND_ERROR                312
-#define IDS_DSOUND_BUFFER_ERROR         313
+#define IDS_SOUND_ERROR                 312
+#define IDS_SOUND_BUFFER_ERROR          313
 #define IDS_EDIT_MODE                   314
 #define IDI_LEFT                        314
 #define IDS_NORMAL_MODE                 315


### PR DESCRIPTION
Results
-------

The commits "Write trailing audio at end of each frame" and "Return immediately from CSoundStream::WaitForReady() if room to write audio" both reduce audio stuttering at lower latencies. (The former is no longer necessary, but harmless to keep.)

Audio results at 1ms latency (actually 22ms on Windows):

- Quite smooth on Windows.
- Mostly smooth on Wine Linux PipeWire nvidia. If you show register state in Dn-FT, this generates considerable Xorg CPU load, and Dn-FT stutters heavily when xorg gets overloaded by switching windows or pressing alt-tab.
  - GUI-linked audio stuttering is tracked in https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/issues/134 and fixed by https://github.com/nyanpasu64/Dn-FamiTracker/tree/rewrite-audio-thread.
- Stutters on M1 Mac Wine (probably a defect in Wine's WASAPI-Core Audio backend).

~~On Windows 7, setting a too-low latency results in an audio hang; just don't do that (this is unchanged from DirectSound FT).~~ Upon further testing, it acts like Windows 10 now, not sure what was going on.

The downside with WASAPI is that you lose "switch devices when default device changes", and picking a sampling rate different from the system rate fails to initialize FT's audio. And any attempts to implement device switching are thwarted by "different devices may have different sampling rates". Ideally audio playback would track the system sampling rate, but we'd still use the options rate for .wav export. This is not implemented.

## Discussion

the changes to internal sound interfaces make it effectively impossible to slot the old directsound backend in as-is, into wasapi famitracker. It may be possible to keep both (and switch between them) if I change DirectSound to fit into the new interface. But I don't feel like doing so.

- [x] ~~Port DirectSound to new interface~~
	- doesn't help, https://github.com/nyanpasu64/Dn-FamiTracker/tree/dsound-low-latency still has awful stuttering on Wine, and failing at <=20ms is due to emulated DirectSound on WASAPI failing to trip interrupts, not FT's fault

there are probably other things that can be done to improve low latency performance, like generating partial frames of audio at a time as they're being output to distribute CPU usage, rather than generating the whole thing upfront and only writing a bit at a time, which is super bursty in CPU utilization, and every burst will lag

- [x] ~~Generate partial frames of audio~~ abandoned

### Issues

- [x] Implement `CSoundStream::ClearBuffer()`
- [x] On Mac Wine, I hear blips of sound when loading different module while playing. Is it related?
	- no. `CSoundStream::ClearBuffer()` is only called on wav export.
	- Does it happen with DirectSound? (yes)
- [x] Fix CMake build

also now picking a different sampling rate from the OS won't work. apparently wasapi won't resample for you? and i didn't bundle a resampler of my own, and don't feel like doing so

- [ ] Add resampler(?)
	- I dislike. Resamplers add latency, CPU usage, and quality degradation. Well they're occasionally useful for deliberately rendering at a different rate. But there should be a "use system rate" option.
- [ ] Use system sampling rate instead of picking rate from settings (affects WAV export too?!)
	- some people have said that tying WAV export to OS sampling rate is not acceptable.
	- It's very bad design for famitracker to fail mysteriously out of the box for half of people with mismatched FT/system sampling rates. But it's hard to make FT only use system rate for system playback, and config rate for wav export.

this is not based off an existing wrapper around wasapi. maybe it would be better that way. but famitracker has idiosyncratic audio design, and would have to be slowly nudged towards playing nicely.

- [ ] ~~Rewrite using an existing multi-backend audio library~~ unlikely

Most audio libraries expose fixed-size periods, which adds latency on top of shared-mode WASAPI's random buffer chunks(?).

might be worth making wasapi optional (also WASAPI doesn't come with auto device switching unless you detect device changes and reinitialize the output stream yourself, possibly even at a different sampling rate!)

also my current wasapi code doesn't report xruns. i couldn't figure out how to ask if the stream ran out of data to play.

- [ ] Report underruns(?)

I don't know of any way to detect playback buffer underruns in WASAPI. https://stackoverflow.com/q/32112562 has no answer, and https://github.com/mackron/miniaudio/issues/81 couldn't figure it out either.

### Wine results

on macos wine, wasapi is *almost* full speed at 40ms latency, whereas DS is slow-motion

wasapi at 50ms latency is full-speed and almost stable, but hitches every minute or so

wasapi lags qualitatively differently from ds, i feel

wine "boost audio thread priority" flat out does nothing (<https://github.com/wine-mirror/wine/blob/1d178982ae5a73b18f367026c8689b56789c39fd/dlls/avrt/main.c#L58>)

## IAudioClient3: simplified buffering on Windows 10

the hard part is that there are actually two ways to create wasapi shared sessions: IAudioClient (allocate the whole buffer, get write access to random portions of it) and IAudioClient3 (Windows 10+ only, pass in 1/2 the buffer size and WASAPI allocates double the size I think, get write access to half at a time)

and writing code to handle both complicates the code and testing

and supporting the former only (the implementation now) has extra latency/jank, and latter only drops old OS support (and doesn't work on Wine: https://github.com/wine-mirror/wine/blob/master/dlls/wineoss.drv/mmdevdrv.c#L1405-L1411)

- [ ] ~~Implement IAudioClient3 or switch to a library that does so~~ abandoned

## [fixed] Visualizer jank

ft's visualizer (`CVisualizerWnd::FlushSamples()`) is not based off a circular buffer. Instead it processes buffers of the same size as audio pushed to the output. and wasapi has variable output buffer size for god knows what reason.

This result in inconsistent oscilloscope drift, and inconsistent spectrogram windowing artifacts.

tbh the visualizer should've been a circular buffer from the beginning, even without the wasapi rewrite. Either make `CVisualizerWnd::FlushSamples()` double-buffer its input, or (possibly easier) make m_iGraphBuffer a ring-buffer flushed when full, independently of `CSoundStream::WriteBuffer()`.

- [x] Buffer visualizer separately from audio output, and rebase this PR on it
- [x] fps is too low (fixed by #127)

### [fixed] Visualizer corruption

on windows 7, win32 release, wasapi 295df072836b7adababdbb79b8283c83a8719f8b is showing random blips on spectrum.

the existing code is wrong.

- [visualizer: m_csBufferSelect] `CVisualizerWnd::ThreadProc(): pDrawBuffer = (m_pFillBuffer=m_pBuffer1)`
- [audio: m_csBuffer] `delete[] m_pBuffer1, edit m_iBufferSize`
- [visualizer: m_csBuffer] `m_pStates[m_iCurrentState]->SetSampleData(pDrawBuffer, m_iBufferSize);`

**To reproduce easily, edit `CVisualizerWnd::ThreadProc()` and add `Sleep(50);` after `m_csBufferSelect.Unlock();` and before `m_csBuffer.Lock();`.**

if this happens on startup, it may index into NULL with a nonzero m_iBufferSize. (I've not been able to get errors to happen on startup though.)

if this happens later on, it may index into a freed array with an altered m_iBufferSize. (This occurs on both master and wasapi, if the sleep is added.)

it's not really much of a problem on DirectSound with equally-sized buffer pieces (only pops up when changing buffer size in settings), but on the WASAPI branch it's definitely a problem since wasapi keeps writing random-sized chunks of audio. (I don't know why it doesn't happen on my main machine, normally, or with 1 or 2 cores of affinity.)

## [fixed] Debugging the crash

Loading WASAPI FT with a sampling rate that doesn't match the system rate fails to load audio. Then changing the sampling rate from the wrong to right rate crashes in CChannelHandler code. I suspect this crash is unrelated to WASAPI, and merely exposed by the "no stream running" state most easily caused by WASAPI.

![crash stack trace](https://cdn.discordapp.com/attachments/939263970940956702/964077170605576202/devenv_JV9B62vR2R.png)

- [x] Fix crash ("Fix crash when starting with wrong sampling rate then fixing afterwards")

## Windows 7

works. but changing audio settings causes app to stop playing audio for ~3 seconds, then display IDS_SOUND_BUFFER_ERROR (`CSoundInterface::OpenChannel()` returns nullptr).

Fixed: commit "Move COM initialization from object to GUI/audio threads"

## Error messages

`CSoundInterface::SetupDevice` failed (invalid device) = `IDS_SOUND_ERROR`
`m_pSoundInterface->OpenChannel` failed (invalid sampling rate) = `IDS_SOUND_BUFFER_ERROR`

## TODO

- [x] Read over code
- [x] Change DirectSound error messages to WASAPI or generic
- [ ] Add error messages for `CSoundInterface::OpenChannel` -> `IDS_SOUND_BUFFER_ERROR` (string and HRESULT): IAudioClient::IsFormatSupported() failed (eg. wrong sampling rate)? IAudioClient::Initialize() failed (COM error)?
- [x] Change error message to "Incorrect sampling rate?"
- [x] Rewrite commit history