### PR TITLE
Fix high-res spectrum visualizer at small buffer sizes

### DIFF
--- a/Source/FFT/FftBuffer.h
+++ b/Source/FFT/FftBuffer.h
@@ -59,18 +59,18 @@ public:
 
 	template <typename InputIt>
 	void CopyIn(InputIt Samples, std::size_t SampleCount) {
-		if (SampleCount > GetPoints()) {
-			SampleCount = GetPoints();
-			std::advance(Samples, SampleCount - GetPoints());
+		if (SampleCount > N) {
+			std::advance(Samples, SampleCount - N);
+			SampleCount = N;
 		}
 		std::copy(samples_.cbegin() + SampleCount, samples_.cend(), samples_.begin());
-		std::transform(Samples, Samples + SampleCount, samples_.begin(), [] (auto x) {
+		std::transform(Samples, Samples + SampleCount, samples_.end() - SampleCount, [] (auto x) {
 			return std::complex<double>(x, 0);
 		});
 	}
 
 	double GetIntensity(int i) const {
-		const double sqrtpoints = 1 << (FFT::details::floor_log2(GetPoints()) / 2);
+		const double sqrtpoints = 1 << (FFT::details::floor_log2(N) / 2);
 		return std::abs(buffer_[i]) / sqrtpoints;
 	}
 


### PR DESCRIPTION
Turns out 0CC's spectrum view's `FftBuffer` tried all along to combine short buffers with the previous buffer contents, but was broken the whole time, making the spectrum look like it failed to handle inputs smaller than the 1024-sample FFT window.

Screenshots at 48000 Hz and buffer size 25 ms:

Before (flickers):
![Dn-FamiTracker_aRTPixruw1](https://user-images.githubusercontent.com/913957/163704571-d9d8e676-551b-45dd-9566-03881d9dcdbd.png)

After (less windowing artifacts, more stable):
![Dn-FamiTracker_9ajZCAc88H](https://user-images.githubusercontent.com/913957/163704575-f108beab-759a-44d0-95a9-2016ede82727.png)

Even with this fix, both the oscilloscope and spectrum visualizer rely on the visualizer thread processing incoming data faster than the audio thread can write new data, on a "best-effort" basis. If the visualizer falls behind, the oscilloscope or spectrum will show a discontinuity in incoming data. The discontinuity will appear at a random point of the oscilloscope. In spectrum mode, it will affect the entire spectrum, but only appears at buffer lengths below 2048 samples.