### PR TITLE
Move graph data windowing from visualizer thread to audio thread

### DIFF
--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -968,7 +968,7 @@ bool CSoundGen::PlayBuffer()
 		m_csVisualizerWndLock.Lock();
 
 		if (m_pVisualizerWnd)
-			m_pVisualizerWnd->FlushSamples(m_iGraphBuffer, m_iBufSizeSamples);
+			m_pVisualizerWnd->FlushSamples(gsl::span(m_iGraphBuffer, m_iBufSizeSamples));
 
 		m_csVisualizerWndLock.Unlock();
 

--- a/Source/VisualizerBase.cpp
+++ b/Source/VisualizerBase.cpp
@@ -38,10 +38,12 @@ void CVisualizerBase::Create(int Width, int Height)
 	m_pBlitBuffer = std::make_unique<COLORREF[]>(Width * Height);		// // //
 }
 
-void CVisualizerBase::SetSampleData(short *pSamples, unsigned int iCount)
-{
-	m_pSamples = pSamples;
-	m_iSampleCount = iCount;
+bool CVisualizerBase::SetScopeData(short const* iSamples, unsigned int iCount) {
+	return false;
+}
+
+bool CVisualizerBase::SetSpectrumData(short const* iSamples, unsigned int iCount) {
+	return false;
 }
 
 void CVisualizerBase::Display(CDC *pDC, bool bPaintMsg) {		// // //

--- a/Source/VisualizerBase.h
+++ b/Source/VisualizerBase.h
@@ -36,8 +36,13 @@ public:
 	virtual void Create(int Width, int Height);
 	// Set rate of samples
 	virtual void SetSampleRate(int SampleRate) = 0;
-	// Set new sample data
-	virtual void SetSampleData(short *iSamples, unsigned int iCount);
+
+	// Set new sample data (block-aligned)
+	virtual bool SetScopeData(short const* iSamples, unsigned int iCount);
+
+	// Set new sample data (latest)
+	virtual bool SetSpectrumData(short const* iSamples, unsigned int iCount);
+
 	// Render an image from the sample data
 	virtual void Draw() = 0;
 	// Display the image
@@ -51,5 +56,5 @@ protected:
 	int m_iHeight = 0;
 
 	unsigned int m_iSampleCount = 0;
-	short *m_pSamples = nullptr;
+	short const* m_pSamples = nullptr;
 };

--- a/Source/VisualizerScope.h
+++ b/Source/VisualizerScope.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "VisualizerBase.h"		// // //
+#include <cstdint>
 
 // CVisualizerScope, scope style visualizer
 
@@ -37,15 +38,16 @@ public:
 
 	void Create(int Width, int Height) override;
 	void SetSampleRate(int SampleRate) override;
+	bool SetScopeData(short const* iSamples, unsigned int iCount) override;
 	void Draw() override;
 	void Display(CDC *pDC, bool bPaintMsg) override;
+	size_t NeededSamples() const;
 
 private:
 	void RenderBuffer();
 	void ClearBackground();
 
 private:
-	int	 m_iWindowBufPtr;
 	short *m_pWindowBuf;
 	bool m_bBlur;
 

--- a/Source/VisualizerSpectrum.cpp
+++ b/Source/VisualizerSpectrum.cpp
@@ -53,38 +53,20 @@ void CVisualizerSpectrum::SetSampleRate(int SampleRate)
 	m_iFillPos = 0;
 }
 
-void CVisualizerSpectrum::Transform(short *pSamples, unsigned int Count)
+void CVisualizerSpectrum::Transform(short const* pSamples, unsigned int Count)
 {
 	fft_buffer_.CopyIn(pSamples, Count);
 	fft_buffer_.Transform();
 }
 
-void CVisualizerSpectrum::SetSampleData(short *pSamples, unsigned int iCount)
+bool CVisualizerSpectrum::SetSpectrumData(short const* pSamples, unsigned int iCount)
 {
-	CVisualizerBase::SetSampleData(pSamples, iCount);
+	m_pSamples = pSamples;
+	m_iSampleCount = iCount;
+	ASSERT(m_iSampleCount == FFT_POINTS);
 
 	Transform(pSamples, iCount);
-	/*
-	int offset = 0;
-
-	if (m_iFillPos > 0) {
-		const int size = std::min((int)iCount, FFT_POINTS - m_iFillPos);
-		std::copy_n(pSamples, size, m_pSampleBuffer.begin() + m_iFillPos);
-		Transform(m_pSampleBuffer.data(), FFT_POINTS);
-		offset += size;
-		iCount -= size;
-	}
-
-	while (iCount >= FFT_POINTS) {
-		Transform(pSamples + offset, FFT_POINTS);
-		offset += FFT_POINTS;
-		iCount -= FFT_POINTS;
-	}
-
-	// Copy rest
-	std::copy_n(pSamples + offset, iCount, m_pSampleBuffer.begin());
-	m_iFillPos = iCount;
-	*/
+	return true;
 }
 
 void CVisualizerSpectrum::Draw()
@@ -100,13 +82,13 @@ void CVisualizerSpectrum::Draw()
 
 	for (int i = 0; i < m_iWidth / m_iBarSize; i++) {		// // //
 		int iStep = int(Pos + 0.5f);
-		
+
 		float level = 0;
 		int steps = (iStep - LastStep) + 1;
 		for (int j = 0; j < steps; ++j)
 			level += float(fft_buffer_.GetIntensity(LastStep + j)) / SCALING;
 		level /= steps;
-		
+
 		// linear -> db
 		level = (20 * std::log10(level));// *0.8f;
 
@@ -138,8 +120,8 @@ void CVisualizerSpectrum::Draw()
 					Color = DIM(Color, 50);
 				m_pBlitBuffer[(m_iHeight - 1 - y) * m_iWidth + i * m_iBarSize + x + OFFSET] = y < level ? Color : BG_COLOR;
 			}
-		}	
-		
+		}
+
 		LastStep = iStep;
 		Pos += Step;
 	}

--- a/Source/VisualizerSpectrum.h
+++ b/Source/VisualizerSpectrum.h
@@ -41,11 +41,11 @@ public:
 
 	void Create(int Width, int Height) override;
 	void SetSampleRate(int SampleRate) override;
-	void SetSampleData(short *iSamples, unsigned int iCount) override;
+	bool SetSpectrumData(short const* pSamples, unsigned int iCount) override;
 	void Draw() override;
 
 protected:
-	void Transform(short *pSamples, unsigned int Count);
+	void Transform(short const* pSamples, unsigned int Count);
 
 private:
 	static const COLORREF BG_COLOR = 0;

--- a/Source/VisualizerWnd.cpp
+++ b/Source/VisualizerWnd.cpp
@@ -28,17 +28,68 @@
 #include "VisualizerScope.h"
 #include "VisualizerSpectrum.h"
 #include "VisualizerStatic.h"
+#include <algorithm>  // std::copy, std::fill
+#include <tuple>
 
-// Thread entry helper
-
-UINT CVisualizerWnd::ThreadProcFunc(LPVOID pParam)
+void TripleBuffer::Initialize(size_t Size)
 {
-	CVisualizerWnd *pObj = reinterpret_cast<CVisualizerWnd*>(pParam);
+	this->pShared = std::make_unique<std::atomic<uint8_t>>(INIT_SHARED);
 
-	if (pObj == NULL || !pObj->IsKindOf(RUNTIME_CLASS(CVisualizerWnd)))
-		return 1;
+	for (size_t i = 0; i < 3; i++) {
+		this->pBuffers[i] = std::make_unique<short[]>(Size);
+		auto pBuffer = this->pBuffers[i].get();
+		std::fill(pBuffer, pBuffer + Size, 0);
+	}
+}
 
-	return pObj->ThreadProc();
+Reader::Reader(TripleBuffer* pBuffer) :
+	m_pBuffer(pBuffer),
+	m_ReadIndex(TripleBuffer::INIT_READ)
+{
+}
+
+Reader::~Reader() = default;
+
+short const* Reader::Curr() const
+{
+	return m_pBuffer->pBuffers[m_ReadIndex].get();
+}
+
+bool Reader::Fetch()
+{
+	if (!(m_pBuffer->pShared->load(std::memory_order_relaxed) & TripleBuffer::SHARED_WRITTEN)) {
+		return false;
+	}
+
+	// Release currently owned buffer and acquire new one to read from.
+	auto readTmp = m_pBuffer->pShared->exchange(m_ReadIndex, std::memory_order_acq_rel);
+	ASSERT(readTmp & TripleBuffer::SHARED_WRITTEN);
+	m_ReadIndex = readTmp & TripleBuffer::SHARED_INDEX;
+	ASSERT(m_ReadIndex < 3);
+	return true;
+}
+
+Writer::Writer(TripleBuffer* pBuffer) :
+	m_pBuffer(pBuffer),
+	m_WriteIndex(TripleBuffer::INIT_WRITE)
+{
+}
+
+Writer::~Writer() = default;
+
+short* Writer::Curr()
+{
+	return m_pBuffer->pBuffers[m_WriteIndex].get();
+}
+
+void Writer::Publish()
+{
+	// Release currently owned buffer and acquire new one to write to.
+	uint8_t writeTmp = m_pBuffer->pShared->exchange(
+		m_WriteIndex | TripleBuffer::SHARED_WRITTEN, std::memory_order_acq_rel
+	);
+	m_WriteIndex = writeTmp & TripleBuffer::SHARED_INDEX;
+	ASSERT(m_WriteIndex < 3);
 }
 
 // CSampleWindow
@@ -46,17 +97,23 @@ UINT CVisualizerWnd::ThreadProcFunc(LPVOID pParam)
 IMPLEMENT_DYNAMIC(CVisualizerWnd, CWnd)
 
 CVisualizerWnd::CVisualizerWnd() :
+	m_pStates(),
 	m_iCurrentState(0),
-	m_bThreadRunning(false),
-	m_pWorkerThread(NULL),
-	m_iBufferSize(0),
-	m_pBuffer1(NULL),
-	m_pBuffer2(NULL),
-	m_pFillBuffer(NULL),
+	m_pScope(nullptr),
+	m_ScopeBufferSize(0),
+	m_pScopeData(std::make_unique<TripleBuffer>()),
+	m_pSpectrumData(std::make_unique<TripleBuffer>()),
+	m_ScopeWriter(m_pScopeData.get()),
+	m_ScopeWriteProgress(0),
+	m_SpectrumWriter(m_pSpectrumData.get()),
+	m_pSpectrumHistory(std::make_unique<short[]>(FFT_POINTS)),
 	m_hNewSamples(NULL),
-	m_bNoAudio(false)
+	m_bNoAudio(false),
+	m_pWorkerThread(NULL),
+	m_bThreadRunning(false),
+	m_csBuffer()
 {
-	m_pStates[0] = new CVisualizerScope(false);
+	m_pStates[0] = m_pScope = new CVisualizerScope(false);
 	m_pStates[1] = new CVisualizerScope(true);
 	m_pStates[2] = new CVisualizerSpectrum(4);		// // //
 	m_pStates[3] = new CVisualizerSpectrum(1);
@@ -68,9 +125,6 @@ CVisualizerWnd::~CVisualizerWnd()
 	for (int i = 0; i < STATE_COUNT; ++i) {		// // //
 		SAFE_RELEASE(m_pStates[i]);
 	}
-
-	SAFE_RELEASE_ARRAY(m_pBuffer1);
-	SAFE_RELEASE_ARRAY(m_pBuffer2);
 }
 
 HANDLE CVisualizerWnd::GetThreadHandle() const {		// // //
@@ -86,10 +140,119 @@ BEGIN_MESSAGE_MAP(CVisualizerWnd, CWnd)
 	ON_WM_DESTROY()
 END_MESSAGE_MAP()
 
+BOOL CVisualizerWnd::CreateEx(DWORD dwExStyle, LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext)
+{
+	// This is saved
+	m_iCurrentState = theApp.GetSettings()->SampleWinState;
+
+	// Create an event used to signal that new samples are available
+	m_hNewSamples = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+	BOOL Result = CWnd::CreateEx(dwExStyle, lpszClassName, lpszWindowName, dwStyle, rect, pParentWnd, nID, pContext);
+
+	if (Result) {
+		// Get client rect and create visualizers
+		CRect crect;
+		GetClientRect(&crect);
+		for (int i = 0; i < STATE_COUNT; ++i) {
+			m_pStates[i]->Create(crect.Width(), crect.Height());
+		}
+
+		m_ScopeBufferSize = m_pScope->NeededSamples();
+
+		// Initialize triple buffer.
+		m_pScopeData->Initialize(m_ScopeBufferSize);
+		m_pSpectrumData->Initialize(FFT_POINTS);
+
+		// Create a worker thread
+		m_pWorkerThread = AfxBeginThread(&ThreadProcFunc, (LPVOID)this, THREAD_PRIORITY_BELOW_NORMAL);
+	}
+
+	return Result;
+}
+
+// Thread entry helper
+
+UINT CVisualizerWnd::ThreadProcFunc(LPVOID pParam)
+{
+	CVisualizerWnd* pObj = reinterpret_cast<CVisualizerWnd*>(pParam);
+
+	if (pObj == NULL || !pObj->IsKindOf(RUNTIME_CLASS(CVisualizerWnd)))
+		return 1;
+
+	return pObj->ThreadProc();
+}
+
+UINT CVisualizerWnd::ThreadProc()
+{
+	DWORD nThreadID = AfxGetThread()->m_nThreadID;
+	m_bThreadRunning.store(true, std::memory_order_release);
+
+	TRACE("Visualizer: Started thread (0x%04x)\n", nThreadID);
+	auto scopeReader = Reader(m_pScopeData.get());
+	auto spectrumReader = Reader(m_pSpectrumData.get());
+
+	while (
+		::WaitForSingleObject(m_hNewSamples, INFINITE) == WAIT_OBJECT_0
+		&& m_bThreadRunning.load(std::memory_order_relaxed)
+	) {
+
+		m_bNoAudio = false;
+
+		bool scopeChanged = scopeReader.Fetch();
+		bool spectrumChanged = spectrumReader.Fetch();
+
+		// CVisualizerWnd::FlushSamples always publishes buffers before signalling
+		// m_hNewSamples, and we just waited for m_hNewSamples to be signalled.
+		// You'd think the buffers are guaranteed to be changed.
+		//
+		// But it's possible CVisualizerWnd::FlushSamples is called again and publishes
+		// again, before we see m_hNewSamples and fetch the new buffer contents.
+		// Then on the next iteration WaitForSingleObject passes but the buffer
+		// isn't changed.
+		//
+		// If this happens, retry the loop instead of drawing unchanged data.
+		//
+		// (This can also happen on program shutdown, when CVisualizerWnd::OnDestroy()
+		// signals m_hNewSamples.)
+		if (!(scopeChanged || spectrumChanged)) {
+			continue;
+		}
+
+		// Draw
+		m_csBuffer.Lock();
+
+		CDC* pDC = GetDC();
+		if (pDC != NULL) {
+			auto* state = m_pStates[m_iCurrentState];
+
+			bool updated = false;
+			if (scopeChanged) {
+				updated |= state->SetScopeData(scopeReader.Curr(), m_ScopeBufferSize);
+			}
+			if (spectrumChanged) {
+				updated |= state->SetSpectrumData(spectrumReader.Curr(), FFT_POINTS);
+			}
+
+			if (updated) {
+				state->Draw();
+				state->Display(pDC, false);
+			}
+			ReleaseDC(pDC);
+		}
+
+		m_csBuffer.Unlock();
+	}
+
+	TRACE("Visualizer: Closed thread (0x%04x)\n", nThreadID);
+
+	return 0;
+}
+
 // State methods
 
 void CVisualizerWnd::NextState()
-{
+{	
 	m_csBuffer.Lock();
 	m_iCurrentState = (m_iCurrentState + 1) % STATE_COUNT;
 	m_csBuffer.Unlock();
@@ -108,25 +271,62 @@ void CVisualizerWnd::SetSampleRate(int SampleRate)
 			state->SetSampleRate(SampleRate);
 }
 
-void CVisualizerWnd::FlushSamples(short *pSamples, int Count)
+void CVisualizerWnd::FlushSamples(gsl::span<const short> Samples)
 {
-	if (!m_bThreadRunning)
+	if (!m_bThreadRunning.load(std::memory_order_acquire))
 		return;
 
-	if (Count != m_iBufferSize) {
-		m_csBuffer.Lock();
-		SAFE_RELEASE_ARRAY(m_pBuffer1);
-		SAFE_RELEASE_ARRAY(m_pBuffer2);
-		m_pBuffer1 = new short[Count];
-		m_pBuffer2 = new short[Count];
-		m_iBufferSize = Count;
-		m_pFillBuffer = m_pBuffer1;
-		m_csBuffer.Unlock();
+	// On GUI thread, buffers are initialized before visualizer thread is started.
+	// After visualizer thread is started, m_bThreadRunning.store(true, Release).
+	// On audio thread, after m_bThreadRunning.load(Acquire) == true, buffers are
+	// initialized.
+
+	// Fill m_pSpectrumHistory. (We can't write incrementally to m_SpectrumWriter.Curr()
+	// because we keep some old data from one publish-swap to the next.)
+	{
+		auto tail = Samples;
+		if (tail.size() > (size_t)FFT_POINTS) {
+			tail = tail.subspan(tail.size() - (size_t)FFT_POINTS);
+		}
+		ASSERT(tail.size() <= (size_t)FFT_POINTS);
+
+		auto history = m_pSpectrumHistory.get();
+		// Push tail to end of history.
+		std::copy(
+			history + tail.size(),
+			history + FFT_POINTS,
+			history);
+		std::copy(
+			tail.begin(),
+			tail.end(),
+			history + FFT_POINTS - tail.size());
+
+		short* pSpectrumBuffer = m_SpectrumWriter.Curr();
+		std::copy(history, history + FFT_POINTS, pSpectrumBuffer);
+		m_SpectrumWriter.Publish();
 	}
 
-	m_csBufferSelect.Lock();
-	memcpy(m_pFillBuffer, pSamples, sizeof(short) * Count);
-	m_csBufferSelect.Unlock();
+	// Fill pScopeBuffer. (We can write incrementally to m_ScopeWriter.Curr() because
+	// we discard all old contents between publishing.)
+	short* pScopeBuffer = m_ScopeWriter.Curr();
+	while (!Samples.empty()) {
+		size_t push = std::min(Samples.size(), m_ScopeBufferSize - m_ScopeWriteProgress);
+		for (size_t i = 0; i < push; i++) {
+			pScopeBuffer[m_ScopeWriteProgress] = Samples[i];
+			m_ScopeWriteProgress++;
+		}
+
+		ASSERT(m_ScopeWriteProgress <= m_ScopeBufferSize);
+		if (m_ScopeWriteProgress == m_ScopeBufferSize) {
+			// Release currently owned buffer and acquire new one to write to.
+			m_ScopeWriter.Publish();
+			pScopeBuffer = m_ScopeWriter.Curr();
+			m_ScopeWriteProgress = 0;
+		}
+
+		// Drop initial samples already processed.
+		Samples = Samples.subspan(push);
+	}
 
 	SetEvent(m_hNewSamples);
 }
@@ -135,73 +335,6 @@ void CVisualizerWnd::ReportAudioProblem()
 {
 	m_bNoAudio = true;
 	Invalidate();
-}
-
-UINT CVisualizerWnd::ThreadProc()
-{
-	DWORD nThreadID = AfxGetThread()->m_nThreadID;
-	m_bThreadRunning = true;
-
-	TRACE("Visualizer: Started thread (0x%04x)\n", nThreadID);
-
-	while (::WaitForSingleObject(m_hNewSamples, INFINITE) == WAIT_OBJECT_0 && m_bThreadRunning) {
-
-		m_bNoAudio = false;
-
-		// Switch buffers
-		m_csBufferSelect.Lock();
-
-		short *pDrawBuffer = m_pFillBuffer;
-
-		if (m_pFillBuffer == m_pBuffer1)
-			m_pFillBuffer = m_pBuffer2;
-		else
-			m_pFillBuffer = m_pBuffer1;
-
-		m_csBufferSelect.Unlock();
-
-		// Draw
-		m_csBuffer.Lock();
-
-		CDC *pDC = GetDC();
-		if (pDC != NULL) {
-			m_pStates[m_iCurrentState]->SetSampleData(pDrawBuffer, m_iBufferSize);
-			m_pStates[m_iCurrentState]->Draw();
-			m_pStates[m_iCurrentState]->Display(pDC, false);
-			ReleaseDC(pDC);
-		}
-
-		m_csBuffer.Unlock();
-	}
-
-	TRACE("Visualizer: Closed thread (0x%04x)\n", nThreadID);
-
-	return 0;
-}
-
-BOOL CVisualizerWnd::CreateEx(DWORD dwExStyle, LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext)
-{	
-	// This is saved
-	m_iCurrentState = theApp.GetSettings()->SampleWinState;
-
-	// Create an event used to signal that new samples are available
-	m_hNewSamples = CreateEvent(NULL, FALSE, FALSE, NULL);
-
-	BOOL Result = CWnd::CreateEx(dwExStyle, lpszClassName, lpszWindowName, dwStyle, rect, pParentWnd, nID, pContext);
-
-	if (Result) {
-		// Get client rect and create visualizers
-		CRect crect;
-		GetClientRect(&crect);
-		for (int i = 0; i < STATE_COUNT; ++i) {
-			m_pStates[i]->Create(crect.Width(), crect.Height());
-		}
-
-		// Create a worker thread
-		m_pWorkerThread = AfxBeginThread(&ThreadProcFunc, (LPVOID)this, THREAD_PRIORITY_BELOW_NORMAL);
-	}
-
-	return Result;
 }
 
 void CVisualizerWnd::OnLButtonDown(UINT nFlags, CPoint point)
@@ -282,7 +415,7 @@ void CVisualizerWnd::OnDestroy()
 	if (m_pWorkerThread != NULL) {
 		HANDLE hThread = m_pWorkerThread->m_hThread;
 		
-		m_bThreadRunning = false;
+		m_bThreadRunning.store(false, std::memory_order_relaxed);
 		::SetEvent(m_hNewSamples);
 
 		TRACE("Visualizer: Joining thread...\n");

--- a/Source/VisualizerWnd.h
+++ b/Source/VisualizerWnd.h
@@ -29,10 +29,65 @@
 
 #include "stdafx.h"		// // //
 #include <afxmt.h>		// Synchronization objects
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <gsl/span>
 
 class CVisualizerBase;		// // //
+class CVisualizerScope;
 
 // CVisualizerWnd
+
+/// https://github.com/nyanpasu64/spectro2/blob/master/flip-cell/src/lib.rs
+class TripleBuffer {
+	// Constants
+	static constexpr uint8_t INIT_WRITE = 0;
+	static constexpr uint8_t INIT_SHARED = 1;
+	static constexpr uint8_t INIT_READ = 2;
+	static constexpr uint8_t SHARED_INDEX = 0x7F;
+	static constexpr uint8_t SHARED_WRITTEN = 0x80;
+
+	// Fields
+	// [3] box[...] short
+	std::unique_ptr<short[]> pBuffers[3];
+
+	// box atomic u8
+	std::unique_ptr<std::atomic<uint8_t>> pShared;
+
+	friend class Reader;
+	friend class Writer;
+
+public:
+	void Initialize(size_t Size);
+};
+
+class Reader {
+	TripleBuffer * m_pBuffer;
+	uint8_t m_ReadIndex;
+
+	friend class TripleBuffer;
+
+public:
+	Reader(TripleBuffer* pBuffer);
+	~Reader();
+	short const* Curr() const;
+	bool Fetch();
+};
+
+class Writer {
+	TripleBuffer* m_pBuffer;
+	uint8_t m_WriteIndex;
+
+	friend class TripleBuffer;
+
+public:
+	Writer(TripleBuffer* pBuffer);
+	~Writer();
+	short* Curr();
+	void Publish();
+};
 
 class CVisualizerWnd : public CWnd
 {
@@ -44,16 +99,19 @@ public:
 
 	HANDLE GetThreadHandle() const;		// // //
 
-	void SetSampleRate(int SampleRate);
-	void FlushSamples(short *Samples, int Count);
-	void ReportAudioProblem();
-
+	// Spawns new thread calling ThreadProc().
+	BOOL CreateEx(DWORD dwExStyle, LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext = NULL);
 private:
 	static UINT ThreadProcFunc(LPVOID pParam);
 
 private:
-	void NextState();
 	UINT ThreadProc();
+	void NextState();
+
+public:
+	void SetSampleRate(int SampleRate);
+	void FlushSamples(gsl::span<const short> Samples);
+	void ReportAudioProblem();
 
 private:
 	static const int STATE_COUNT = 5;		// // //
@@ -61,11 +119,21 @@ private:
 private:
 	CVisualizerBase *m_pStates[STATE_COUNT];
 	std::size_t m_iCurrentState;
+	CVisualizerScope* m_pScope;  // Non-owning, points within m_pStates.
 
-	int	m_iBufferSize;
-	short *m_pBuffer1;
-	short *m_pBuffer2;
-	short *m_pFillBuffer;
+	// Samples/frames.
+	std::size_t m_ScopeBufferSize;
+
+	// Triple-buffer between audio and visualizer threads:
+	std::unique_ptr<TripleBuffer> m_pScopeData;
+	std::unique_ptr<TripleBuffer> m_pSpectrumData;
+
+	// box u8 (written by audio thread)
+	Writer m_ScopeWriter;
+	size_t m_ScopeWriteProgress;
+
+	Writer m_SpectrumWriter;
+	std::unique_ptr<short[]> m_pSpectrumHistory;
 
 	HANDLE m_hNewSamples;
 
@@ -73,13 +141,9 @@ private:
 
 	// Thread
 	CWinThread *m_pWorkerThread;
-	bool m_bThreadRunning;
+	std::atomic<bool> m_bThreadRunning;
 
-	CCriticalSection m_csBufferSelect;
 	CCriticalSection m_csBuffer;
-
-public:
-	virtual BOOL CreateEx(DWORD dwExStyle, LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext = NULL);
 
 protected:
 	DECLARE_MESSAGE_MAP()


### PR DESCRIPTION
## Description

With this change, the audio thread no longer needs to allocate memory or acquire locks to send graph data to the visualizer thread. Unfortunately, the audio thread still needs to lock the document so the sequencer and driver can read it.

This also eliminates visualizer discontinuities which occur during lag (the old code treated a double buffer as a queue). **Unfortunately the visualizer is slightly more choppy at buffer sizes 40ms and above on DirectSound**; the visualizer is still smooth on the WASAPI branch.

This change also fixes a race condition causing the visualizer thread's `CVisualizerWnd::ThreadProc()` to pass freed memory (`pDrawBuffer`) to `CVisualizerBase::SetSampleData()`. This could occur randomly upon changing buffer size on DirectSound, or randomly on WASAPI. When it happens, the visualizer can display corrupted contents or even segfault.

To reproduce the bug easily, checkout master without this branch's changes, then edit `CVisualizerWnd::ThreadProc()` and add `Sleep(50);` after `m_csBufferSelect.Unlock();` before `m_csBuffer.Lock();`.

### Edge cases

> CVisualizerWnd::FlushSamples always publishes buffers before signalling m_hNewSamples, and we just waited for m_hNewSamples to be signalled. You'd think the buffers are guaranteed to be changed.
> 
> But it's possible CVisualizerWnd::FlushSamples is called again and publishes again, before we see m_hNewSamples and fetch the new buffer contents. Then on the next iteration WaitForSingleObject passes but the buffer isn't changed.
> 
> If this happens, retry the loop instead of drawing unchanged data.
> 
> (This can also happen on program shutdown, when CVisualizerWnd::OnDestroy() signals m_hNewSamples.) 

To reproduce easily, follow these steps:

- edit `CVisualizerWnd::ThreadProc()` and add `Sleep(rand() % 20)` before `m_bNoAudio = false;`
- edit `CVisualizerWnd::FlushSamples()` and add `Sleep(rand() % 20)` before `SetEvent(m_hNewSamples);`
- add `ASSERT(false);` (triggers in debug mode) inside `if (!(scopeChanged || spectrumChanged))`

## Audio stuttering not fixed

I had hoped that this change would make audio not cut out when maximizing/minimizing other windows on Windows 7 Classic theme (compositing turned off, so window animations block the whole desktop). Unfortunately, even with a wait-free audio visualizer interface, the audio thread still stops playing when i perform windowing operations. I suspect the audio stops due to either document lock contention or the MFC event loop not calling OnIdle to perform synthesis, though the actual cause may be different.

UPDATE: It's the MFC event loop not calling OnIdle to perform synthesis.

**This PR lives on top of https://github.com/nyanpasu64/Dn-FamiTracker/tree/wasapi, but I want Dn CI to run.**