### PR TITLE
Fix use-after-free race condition in visualizer

### DIFF
--- a/Source/VisualizerWnd.cpp
+++ b/Source/VisualizerWnd.cpp
@@ -149,6 +149,7 @@ UINT CVisualizerWnd::ThreadProc()
 		m_bNoAudio = false;
 
 		// Switch buffers
+		m_csBuffer.Lock();
 		m_csBufferSelect.Lock();
 
 		short *pDrawBuffer = m_pFillBuffer;
@@ -161,8 +162,6 @@ UINT CVisualizerWnd::ThreadProc()
 		m_csBufferSelect.Unlock();
 
 		// Draw
-		m_csBuffer.Lock();
-
 		CDC *pDC = GetDC();
 		if (pDC != NULL) {
 			m_pStates[m_iCurrentState]->SetSampleData(pDrawBuffer, m_iBufferSize);
@@ -180,7 +179,7 @@ UINT CVisualizerWnd::ThreadProc()
 }
 
 BOOL CVisualizerWnd::CreateEx(DWORD dwExStyle, LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext)
-{	
+{
 	// This is saved
 	m_iCurrentState = theApp.GetSettings()->SampleWinState;
 
@@ -281,7 +280,7 @@ void CVisualizerWnd::OnDestroy()
 	// Shut down worker thread
 	if (m_pWorkerThread != NULL) {
 		HANDLE hThread = m_pWorkerThread->m_hThread;
-		
+
 		m_bThreadRunning = false;
 		::SetEvent(m_hNewSamples);
 

--- a/Source/VisualizerWnd.h
+++ b/Source/VisualizerWnd.h
@@ -75,7 +75,9 @@ private:
 	CWinThread *m_pWorkerThread;
 	bool m_bThreadRunning;
 
+	// Held while (visualizer) switching m_pFillBuffer or (audio) writing to m_pFillBuffer.
 	CCriticalSection m_csBufferSelect;
+	// Held while (visualizer) reading either buffer or (audio) reallocating both buffers.
 	CCriticalSection m_csBuffer;
 
 public:


### PR DESCRIPTION
Fixes a race condition causing the visualizer thread's `CVisualizerWnd::ThreadProc()` to pass freed memory (`pDrawBuffer`) to `CVisualizerBase::SetSampleData()`. This could occur randomly upon changing buffer size on DirectSound, or randomly on WASAPI. When it happens, the visualizer can display corrupted contents or even segfault.

To reproduce the bug easily, checkout master without this branch's changes, then edit `CVisualizerWnd::ThreadProc()` and add `Sleep(50);` after `m_csBufferSelect.Unlock();` before `m_csBuffer.Lock();`.

This does not rewrite the entire visualizer system unlike #127. This is good since master (and this branch)'s oscilloscope visualizer is less choppy on DirectSound than #127, and WASAPI (which replaces DirectSound) isn't merged yet.