### PR TITLE
Eliminate audio thread blocking on GUI messages and main thread

### DIFF
--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -642,6 +642,7 @@ makehm /h /a afxhh.h IDW_,HIDW_,0x50000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.
     <ClInclude Include="Source\type_safe\types.hpp" />
     <ClInclude Include="Source\type_safe\variant.hpp" />
     <ClInclude Include="Source\type_safe\visitor.hpp" />
+    <ClInclude Include="Source\utils\handle_ptr.h" />
     <ClInclude Include="Source\utils\variadic_minmax.h" />
     <ClInclude Include="Source\utils\ftmath.h" />
     <ClInclude Include="Source\utils\input.h" />

--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -587,6 +587,7 @@ makehm /h /a afxhh.h IDW_,HIDW_,0x50000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.
     <ClInclude Include="Source\ModuleException.h" />
     <ClInclude Include="Source\OldSequence.h" />
     <ClInclude Include="Source\PatternNote.h" />
+    <ClInclude Include="Source\rigtorp\SPSCQueue.h" />
     <ClInclude Include="Source\SeqInstHandler2A03Pulse.h" />
     <ClInclude Include="Source\SeqInstHandlerS5B.h" />
     <ClInclude Include="Source\SeqInstHandlerSawtooth.h" />

--- a/Dn-FamiTracker.vcxproj.filters
+++ b/Dn-FamiTracker.vcxproj.filters
@@ -1493,6 +1493,9 @@
     <ClInclude Include="Source\ConfigEmulation.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Source\utils\handle_ptr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Dn-FamiTracker.rc">

--- a/Dn-FamiTracker.vcxproj.filters
+++ b/Dn-FamiTracker.vcxproj.filters
@@ -1496,6 +1496,9 @@
     <ClInclude Include="Source\utils\handle_ptr.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Source\rigtorp\SPSCQueue.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="Dn-FamiTracker.rc">

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -156,7 +156,7 @@ BOOL CFamiTrackerApp::InitInstance()
 
 	//who: added by Derek Andrews <derek.george.andrews@gmail.com>
 	//why: Load all custom exporter plugins on startup.
-	
+
 	TCHAR pathToPlugins[MAX_PATH];
 	GetModuleFileName(NULL, pathToPlugins, MAX_PATH);
 	PathRemoveFileSpec(pathToPlugins);
@@ -193,14 +193,14 @@ BOOL CFamiTrackerApp::InitInstance()
 	// Register the application's document templates.  Document templates
 	//  serve as the connection between documents, frame windows and views
 	CDocTemplate0CC* pDocTemplate = new CDocTemplate0CC(		// // //
-		IDR_MAINFRAME, 
-		RUNTIME_CLASS(CFamiTrackerDoc), 
-		RUNTIME_CLASS(CMainFrame), 
+		IDR_MAINFRAME,
+		RUNTIME_CLASS(CFamiTrackerDoc),
+		RUNTIME_CLASS(CMainFrame),
 		RUNTIME_CLASS(CFamiTrackerView));
 
 	if (!pDocTemplate)
 		return FALSE;
-	
+
 	if (m_pDocManager == NULL)		// // //
 		m_pDocManager = new CDocManager0CC { };
 	m_pDocManager->AddDocTemplate(pDocTemplate);
@@ -262,7 +262,7 @@ BOOL CFamiTrackerApp::InitInstance()
 	//  In an SDI app, this should occur after ProcessShellCommand
 	// Enable drag/drop open
 	m_pMainWnd->DragAcceptFiles();
-	
+
 	// Initialize the sound interface, also resumes the thread
 	if (!m_pSoundGenerator->InitializeSound()) {
 		// If failed, restore and save default settings
@@ -272,10 +272,10 @@ BOOL CFamiTrackerApp::InitInstance()
 		AfxMessageBox(IDS_START_ERROR, MB_ICONERROR);
 		return FALSE;
 	}
-	
+
 	// Initialize midi unit
 	m_pMIDI->Init();
-	
+
 	if (cmdInfo.m_bPlay)
 		theApp.StartPlayer(MODE_PLAY);
 
@@ -372,7 +372,7 @@ BOOL CFamiTrackerApp::PreTranslateMessage(MSG* pMsg)
 void CFamiTrackerApp::CheckAppThemed()
 {
 	HMODULE hinstDll = ::LoadLibrary(_T("UxTheme.dll"));
-	
+
 	if (hinstDll) {
 		typedef BOOL (*ISAPPTHEMEDPROC)();
 		ISAPPTHEMEDPROC pIsAppThemed;
@@ -386,7 +386,7 @@ void CFamiTrackerApp::CheckAppThemed()
 }
 
 bool CFamiTrackerApp::IsThemeActive() const
-{ 
+{
 	return m_bThemeActive;
 }
 
@@ -415,7 +415,7 @@ bool GetFileVersion(LPCTSTR Filename, WORD &Major, WORD &Minor, WORD &Revision, 
 			else
 				Success = false;
 		}
-		else 
+		else
 			Success = false;
 
 		SAFE_RELEASE_ARRAY(pData);
@@ -541,7 +541,7 @@ void CFamiTrackerApp::RegisterSingleInstance()
 
 	if (m_hWndMapFile != NULL) {
 		LPTSTR pBuf = (LPTSTR) MapViewOfFile(m_hWndMapFile, FILE_MAP_ALL_ACCESS, 0, 0, SHARED_MEM_SIZE);
-		if (pBuf != NULL) { 
+		if (pBuf != NULL) {
 			// Create a string of main window handle
 			_itot_s((int)GetMainWnd()->m_hWnd, pBuf, SHARED_MEM_SIZE, 10);
 			UnmapViewOfFile(pBuf);
@@ -550,7 +550,7 @@ void CFamiTrackerApp::RegisterSingleInstance()
 }
 
 void CFamiTrackerApp::UnregisterSingleInstance()
-{	
+{
 	// Close shared memory area
 	if (m_hWndMapFile) {
 		CloseHandle(m_hWndMapFile);
@@ -567,9 +567,9 @@ void CFamiTrackerApp::CheckNewVersion(bool StartUp)		// // //
 }
 
 bool CFamiTrackerApp::CheckSingleInstance(CFTCommandLineInfo &cmdInfo)
-{	
+{
 	// Returns true if program should close
-	
+
 	if (!GetSettings()->General.bSingleInstance)
 		return false;
 
@@ -581,7 +581,7 @@ bool CFamiTrackerApp::CheckSingleInstance(CFTCommandLineInfo &cmdInfo)
 	if (GetLastError() == ERROR_ALREADY_EXISTS) {
 		// Another instance detected, get window handle
 		HANDLE hMapFile = OpenFileMapping(FILE_MAP_ALL_ACCESS, FALSE, FT_SHARED_MEM_NAME);
-		if (hMapFile != NULL) {	
+		if (hMapFile != NULL) {
 			LPCTSTR pBuf = (LPTSTR) MapViewOfFile(hMapFile, FILE_MAP_ALL_ACCESS, 0, 0, SHARED_MEM_SIZE);
 			if (pBuf != NULL) {
 				// Get window handle
@@ -608,7 +608,7 @@ bool CFamiTrackerApp::CheckSingleInstance(CFTCommandLineInfo &cmdInfo)
 			CloseHandle(hMapFile);
 		}
 	}
-	
+
 	return false;
 }
 
@@ -649,7 +649,7 @@ int CFamiTrackerApp::GetCPUUsage() const
 		m_hThread,
 		m_pSoundGenerator->m_hThread,
 		GetMainFrame()->GetVisualizerWnd()->GetThreadHandle(),
-	};	
+	};
 
 	static FILETIME KernelLastTime[std::size(hThreads)] = { };
 	static FILETIME UserLastTime[std::size(hThreads)] = { };
@@ -723,7 +723,7 @@ BOOL CFamiTrackerApp::OnIdle(LONG lCount)		// // //
 }
 
 void CFamiTrackerApp::OnVersionCheck()
-{	
+{
 	CVersionCheckerDlg VCDlg;
 	VCDlg.DoModal();
 }
@@ -796,7 +796,7 @@ void CFamiTrackerApp::ResetPlayer()
 
 // File load/save
 
-void CFamiTrackerApp::OnFileOpen() 
+void CFamiTrackerApp::OnFileOpen()
 {
 	CString newName = _T("");		// // //
 
@@ -804,10 +804,10 @@ void CFamiTrackerApp::OnFileOpen()
 		return; // open cancelled
 
 	CFrameWnd *pFrameWnd = (CFrameWnd*)GetMainWnd();
-	
+
 	if (pFrameWnd)
 		pFrameWnd->SetMessageText(IDS_LOADING_FILE);
-	
+
 	AfxGetApp()->OpenDocumentFile(newName);
 
 	if (pFrameWnd)
@@ -889,9 +889,9 @@ CString MakeFloatString(float val, LPCTSTR format)
  *
  */
 
-CFTCommandLineInfo::CFTCommandLineInfo() : CCommandLineInfo(), 
-	m_bLog(false), 
-	m_bExport(false), 
+CFTCommandLineInfo::CFTCommandLineInfo() : CCommandLineInfo(),
+	m_bLog(false),
+	m_bExport(false),
 	m_bPlay(false),
 	m_bHelp(false),		// // !!
 	m_strExportFile(_T("")),
@@ -917,7 +917,7 @@ void CFTCommandLineInfo::ParseParam(const TCHAR* pszParam, BOOL bFlag, BOOL bLas
 			return;
 		}
 		// Disable crash dumps (/nodump)
-		else if (!_tcsicmp(pszParam, _T("nodump"))) { 
+		else if (!_tcsicmp(pszParam, _T("nodump"))) {
 #ifdef ENABLE_CRASH_HANDLER
 			UninstallExceptionHandler();
 #endif

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -60,10 +60,6 @@ const TCHAR FT_SHARED_MUTEX_NAME[]	= _T("FamiTrackerMutex");	// Name of global m
 const TCHAR FT_SHARED_MEM_NAME[]	= _T("FamiTrackerWnd");		// Name of global memory area
 const DWORD	SHARED_MEM_SIZE			= 256;
 
-#ifdef _DEBUG
-#define new DEBUG_NEW
-#endif
-
 // CFamiTrackerApp
 
 BEGIN_MESSAGE_MAP(CFamiTrackerApp, CWinApp)

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -79,10 +79,6 @@
 
 using json = nlohmann::json;
 
-#ifdef _DEBUG
-#define new DEBUG_NEW
-#endif
-
 const char* CFamiTrackerDoc::NEW_INST_NAME = "";
 
 // Make 1 channel default since 8 sounds bad

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -478,15 +478,17 @@ void CFamiTrackerView::SetupColors()
 void CFamiTrackerView::UpdateMeters()
 {
 	// TODO: Change this to use the ordinary drawing routines
-	m_csDrawLock.Lock();
+	{
+		// "what is the use of a mutex that only one thread locks?"
+		// "what is the sound of one hand clapping?"
+		std::unique_lock<std::mutex> lock(m_csDrawLock);
 
-	CDC *pDC = GetDC();
-	if (pDC && pDC->m_hDC) {
-		m_pPatternEditor->DrawMeters(pDC);
-		ReleaseDC(pDC);
+		CDC* pDC = GetDC();
+		if (pDC && pDC->m_hDC) {
+			m_pPatternEditor->DrawMeters(pDC);
+			ReleaseDC(pDC);
+		}
 	}
-
-	m_csDrawLock.Unlock();
 }
 
 void CFamiTrackerView::InvalidateCursor()

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -54,10 +54,6 @@
 
 using std::get_if;
 
-#ifdef _DEBUG
-#define new DEBUG_NEW
-#endif
-
 // Clipboard ID
 const TCHAR CFamiTrackerView::CLIPBOARD_ID[] = _T("FamiTracker Pattern");
 

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -130,7 +130,7 @@ const int NOTE_ECHO = -16;		// // //
 const int SINGLE_STEP = 1;				// Size of single step moves (default: 1)
 
 // Timer IDs
-enum { 
+enum {
 	TMR_UPDATE,
 	TMR_SCROLL
 };
@@ -147,11 +147,11 @@ BEGIN_MESSAGE_MAP(CFamiTrackerView, CView)
 	ON_WM_TIMER()
 	ON_WM_VSCROLL()
 	ON_WM_HSCROLL()
-	
+
 	ON_WM_KEYDOWN()
 	ON_WM_CHAR()
 	ON_WM_KEYUP()
-	
+
 	ON_WM_MOUSEMOVE()
 	ON_WM_MOUSEWHEEL()
 	ON_WM_LBUTTONDOWN()
@@ -180,7 +180,7 @@ BEGIN_MESSAGE_MAP(CFamiTrackerView, CView)
 	ON_COMMAND(ID_CMD_INCREASESTEPSIZE, OnIncreaseStepSize)
 	ON_COMMAND(ID_CMD_DECREASESTEPSIZE, OnDecreaseStepSize)
 	ON_COMMAND(ID_CMD_STEP_UP, OnOneStepUp)
-	ON_COMMAND(ID_CMD_STEP_DOWN, OnOneStepDown)	
+	ON_COMMAND(ID_CMD_STEP_DOWN, OnOneStepDown)
 	ON_COMMAND(ID_POPUP_TOGGLECHANNEL, OnTrackerToggleChannel)
 	ON_COMMAND(ID_POPUP_SOLOCHANNEL, OnTrackerSoloChannel)
 	ON_COMMAND(ID_POPUP_UNMUTEALLCHANNELS, OnTrackerUnmuteAllChannels)
@@ -191,7 +191,7 @@ BEGIN_MESSAGE_MAP(CFamiTrackerView, CView)
 	ON_UPDATE_COMMAND_UI(ID_TRACKER_EDIT, OnUpdateTrackerEdit)
 	ON_UPDATE_COMMAND_UI(ID_EDIT_PASTEMIX, OnUpdateEditPaste)
 	ON_WM_NCMOUSEMOVE()
-	ON_COMMAND(ID_BLOCK_START, OnBlockStart)	
+	ON_COMMAND(ID_BLOCK_START, OnBlockStart)
 	ON_COMMAND(ID_BLOCK_END, OnBlockEnd)
 	ON_COMMAND(ID_POPUP_PICKUPROW, OnPickupRow)
 	ON_MESSAGE(WM_USER_MIDI_EVENT, OnUserMidiEvent)
@@ -277,7 +277,7 @@ static int ConvertKeyExtra(Keycode Key)		// // //
 
 // CFamiTrackerView construction/destruction
 
-CFamiTrackerView::CFamiTrackerView() : 
+CFamiTrackerView::CFamiTrackerView() :
 	mClipboardFormat(0),
 	m_iInsertKeyStepping(1),
 	m_bEditEnable(false),
@@ -491,7 +491,7 @@ void CFamiTrackerView::UpdateMeters()
 
 void CFamiTrackerView::InvalidateCursor()
 {
-	// Cursor has moved, redraw screen	
+	// Cursor has moved, redraw screen
 	m_pPatternEditor->InvalidateCursor();
 	RedrawPatternEditor();
 	RedrawFrameEditor();
@@ -545,7 +545,7 @@ void CFamiTrackerView::RedrawPatternEditor()
 
 void CFamiTrackerView::RedrawFrameEditor()
 {
-	// Redraw the frame editor	
+	// Redraw the frame editor
 	CFrameEditor *pFrameEditor = GetFrameEditor();
 	pFrameEditor->RedrawFrameEditor();
 }
@@ -613,7 +613,7 @@ void CFamiTrackerView::CalcWindowRect(LPRECT lpClientRect, UINT nAdjustType)
 	m_pPatternEditor->InvalidateBackground();
 	// Update cursor since first visible channel might change
 	m_pPatternEditor->CursorUpdated();
-	
+
 	CView::CalcWindowRect(lpClientRect, nAdjustType);
 }
 
@@ -648,7 +648,7 @@ void CFamiTrackerView::OnRButtonUp(UINT nFlags, CPoint point)
 	// Popup menu
 	CRect WinRect;
 	CMenu *pPopupMenu, PopupMenuBar;
-	
+
 	if (m_pPatternEditor->CancelDragging()) {
 		InvalidateCursor();
 		CView::OnRButtonUp(nFlags, point);
@@ -681,7 +681,7 @@ void CFamiTrackerView::OnRButtonUp(UINT nFlags, CPoint point)
 		// Send messages to parent in order to get the menu options working
 		pPopupMenu->TrackPopupMenu(TPM_RIGHTBUTTON, point.x + WinRect.left, point.y + WinRect.top, GetParentFrame());
 	}
-	
+
 	CView::OnRButtonUp(nFlags, point);
 }
 
@@ -690,7 +690,7 @@ void CFamiTrackerView::OnLButtonDown(UINT nFlags, CPoint point)
 	SetTimer(TMR_SCROLL, 10, NULL);
 
 	m_pPatternEditor->OnMouseDown(point);
-	SetCapture();	// Capture mouse 
+	SetCapture();	// Capture mouse
 	InvalidateCursor();
 
 	if (m_pPatternEditor->IsOverHeader(point))
@@ -771,7 +771,7 @@ void CFamiTrackerView::OnMouseMove(UINT nFlags, CPoint point)
 		if (m_pPatternEditor->OnMouseHover(nFlags, point))
 			InvalidateHeader();
 	}
-	
+
 	CView::OnMouseMove(nFlags, point);
 }
 
@@ -805,7 +805,7 @@ BOOL CFamiTrackerView::OnMouseWheel(UINT nFlags, short zDelta, CPoint pt)
 	}
 	else
 		InvalidateCursor();
-	
+
 	return CView::OnMouseWheel(nFlags, zDelta, pt);
 }
 
@@ -844,7 +844,7 @@ void CFamiTrackerView::OnTimer(UINT_PTR nIDEvent)
 	}
 	switch (nIDEvent) {
 		// Drawing updates when playing
-		case TMR_UPDATE: 
+		case TMR_UPDATE:
 			PeriodicUpdate();
 			break;
 
@@ -1046,7 +1046,7 @@ void CFamiTrackerView::OnTrackerEdit()
 		GetParentFrame()->SetMessageText(IDS_EDIT_MODE);
 	else
 		GetParentFrame()->SetMessageText(IDS_NORMAL_MODE);
-	
+
 	m_pPatternEditor->InvalidateBackground();
 	m_pPatternEditor->InvalidateHeader();
 	m_pPatternEditor->InvalidateCursor();
@@ -1323,7 +1323,7 @@ void CFamiTrackerView::OnInitialUpdate()
 	// Setup speed/tempo (TODO remove?)
 	theApp.GetSoundGenerator()->ResetState();
 	theApp.GetSoundGenerator()->ResetTempo();
-	theApp.GetSoundGenerator()->SetMeterDecayRate(theApp.GetSettings()->MeterDecayRate);		// // // 050B	
+	theApp.GetSoundGenerator()->SetMeterDecayRate(theApp.GetSettings()->MeterDecayRate);		// // // 050B
 	theApp.GetSoundGenerator()->DocumentPropertiesChanged(pDoc);		// // //
 
 	// Default
@@ -1352,7 +1352,7 @@ void CFamiTrackerView::OnInitialUpdate()
 		pMainFrame->PostMessage(WM_COMMAND, ID_MODULE_COMMENTS);
 
 	// Call OnUpdate
-	//CView::OnInitialUpdate();	
+	//CView::OnInitialUpdate();
 }
 
 void CFamiTrackerView::RefreshFrameEditor()
@@ -1550,7 +1550,7 @@ bool CFamiTrackerView::IsMarkerValid() const		// // //
 {
 	if (m_iMarkerFrame < 0 || m_iMarkerRow < 0)
 		return false;
-	
+
 	CFamiTrackerDoc* pDoc = GetDocument();
 	ASSERT_VALID(pDoc);
 
@@ -1576,7 +1576,7 @@ void CFamiTrackerView::PlayerTick()
 	// auto arpeggio
 	int OldPtr = m_iAutoArpPtr;
 	do {
-		m_iAutoArpPtr = (m_iAutoArpPtr + 1) & 127;				
+		m_iAutoArpPtr = (m_iAutoArpPtr + 1) & 127;
 		if (m_iAutoArpNotes[m_iAutoArpPtr] == 1) {
 			m_iLastAutoArpPtr = m_iAutoArpPtr;
 			m_iArpeggiate[m_pPatternEditor->GetChannel()] = m_iAutoArpPtr;
@@ -1595,7 +1595,7 @@ bool CFamiTrackerView::PlayerGetNote(int Track, int Frame, int Channel, int Row,
 	bool ValidCommand = false;
 
 	pDoc->GetNoteData(Track, Frame, Channel, Row, &NoteData);
-	
+
 	if (!IsChannelMuted(Channel)) {
 		// Let view know what is about to play
 		PlayerPlayNote(Channel, &NoteData);
@@ -1605,7 +1605,7 @@ bool CFamiTrackerView::PlayerGetNote(int Track, int Frame, int Channel, int Row,
 		// These effects will pass even if the channel is muted
 		const int PASS_EFFECTS[] = {EF_HALT, EF_JUMP, EF_SPEED, EF_SKIP, EF_GROOVE};		// // //
 		int Columns = pDoc->GetEffColumns(Track, Channel) + 1;
-		
+
 		NoteData.Note		= HALT;
 		NoteData.Octave		= 0;
 		NoteData.Instrument = 0;
@@ -1635,13 +1635,13 @@ void CFamiTrackerView::PlayerPlayNote(int Channel, stChanNote *pNote)
 	}
 }
 
-unsigned int CFamiTrackerView::GetSelectedFrame() const 
-{ 
-	return m_pPatternEditor->GetFrame(); 
+unsigned int CFamiTrackerView::GetSelectedFrame() const
+{
+	return m_pPatternEditor->GetFrame();
 }
 
-unsigned int CFamiTrackerView::GetSelectedChannel() const 
-{ 
+unsigned int CFamiTrackerView::GetSelectedChannel() const
+{
 	return m_pPatternEditor->GetChannel();
 }
 
@@ -1657,8 +1657,8 @@ void CFamiTrackerView::SetFollowMode(bool Mode)
 }
 
 bool CFamiTrackerView::GetFollowMode() const
-{ 
-	return m_bFollowMode; 
+{
+	return m_bFollowMode;
 }
 
 void CFamiTrackerView::SetCompactMode(bool Mode)		// // //
@@ -1918,7 +1918,7 @@ void CFamiTrackerView::ToggleChip(unsigned int Channel)		// // //
 
 	if (Channel >= unsigned(channels))
 		return;
-	
+
 	int Chip = pDoc->GetChipType(Channel);
 	for (int i = 0; i < channels; ++i)
 		if (pDoc->GetChipType(i) == Chip && !IsChannelMuted(i)) {
@@ -1928,7 +1928,7 @@ void CFamiTrackerView::ToggleChip(unsigned int Channel)		// // //
 			InvalidateHeader();
 			return;
 		}
-	
+
 	for (int j = 0; j < channels; ++j) if (pDoc->GetChipType(j) == Chip)
 		SetChannelMute(j, false);
 
@@ -1983,7 +1983,7 @@ void CFamiTrackerView::MuteAllChannels() {
 
 bool CFamiTrackerView::IsChannelSolo(unsigned int Channel) const
 {
-	// Returns true if Channel is the only active channel 
+	// Returns true if Channel is the only active channel
 	CFamiTrackerDoc* pDoc = GetDocument();
 	ASSERT_VALID(pDoc);
 
@@ -2001,7 +2001,7 @@ bool CFamiTrackerView::IsChipSolo(unsigned int Chip) const		// // //
 	ASSERT_VALID(pDoc);
 
 	int channels = pDoc->GetAvailableChannels();
-	
+
 	for (int i = 0; i < channels; ++i)
 		if (!IsChannelMuted(i) && pDoc->GetChipType(i) != Chip)
 			return false;
@@ -2043,7 +2043,7 @@ void CFamiTrackerView::SetInstrument(int Instrument)
 	m_iLastInstrument = GetInstrument(); // Gets actual selected instrument //  Instrument;
 }
 
-unsigned int CFamiTrackerView::GetInstrument() const 
+unsigned int CFamiTrackerView::GetInstrument() const
 {
 	CMainFrame *pMainFrm = static_cast<CMainFrame*>(GetParentFrame());
 	ASSERT_VALID(pMainFrm);
@@ -2099,7 +2099,7 @@ void CFamiTrackerView::InsertNote(int Note, int Octave, int Channel, int Velocit
 				SplitKeyboardAdjust(Cell);
 
 		}
-	}	
+	}
 
 	// Quantization
 	if (theApp.GetSettings()->Midi.bMidiMasterSync) {
@@ -2109,7 +2109,7 @@ void CFamiTrackerView::InsertNote(int Note, int Octave, int Channel, int Velocit
 			Cell.EffParam[0] = Delay;
 		}
 	}
-	
+
 	if (m_bEditEnable) {
 		if (Note == HALT)
 			m_iLastNote = NOTE_HALT;
@@ -2123,7 +2123,7 @@ void CFamiTrackerView::InsertNote(int Note, int Octave, int Channel, int Velocit
 		else {
 			m_iLastNote = (Note - 1) + Octave * 12;
 		}
-		
+
 		CPatternAction *pAction = new CPActionEditNote(Cell);		// // //
 		if (AddAction(pAction)) {
 			const CSettings *pSettings = theApp.GetSettings();
@@ -2149,7 +2149,7 @@ void CFamiTrackerView::PlayNote(unsigned int Channel, unsigned int Note, unsigne
 	NoteData.Instrument	= GetInstrument();
 	if (theApp.GetSettings()->Midi.bMidiVelocity)
 		NoteData.Vol = Velocity / 8;
-/*	
+/*
 	if (theApp.GetSettings()->General.iEditStyle == EDIT_STYLE_IT)
 		NoteData.Instrument	= m_iLastInstrument;
 	else
@@ -2180,7 +2180,7 @@ void CFamiTrackerView::PlayNote(unsigned int Channel, unsigned int Note, unsigne
 			pDoc->GetNoteData(Track, Frame, i, Row, &ChanNote);
 			if (!m_bMuteChannels[i] && i != Channel)
 				theApp.GetSoundGenerator()->QueueNote(i, ChanNote, (i == Channel) ? NOTE_PRIO_2 : NOTE_PRIO_1);
-		}	
+		}
 	}
 }
 
@@ -2191,7 +2191,7 @@ void CFamiTrackerView::ReleaseNote(unsigned int Channel, unsigned int Note, unsi
 
 	NoteData.Note = RELEASE;
 	NoteData.Instrument = GetInstrument();
-	
+
 	SplitAdjustChannel(Channel, NoteData);		// // //
 	CFamiTrackerDoc *pDoc = GetDocument();		// // //
 	if (Channel < static_cast<unsigned>(pDoc->GetChannelCount())) {
@@ -2220,7 +2220,7 @@ void CFamiTrackerView::HaltNote(unsigned int Channel, unsigned int Note, unsigne
 
 	NoteData.Note = HALT;
 	NoteData.Instrument = GetInstrument();
-	
+
 	SplitAdjustChannel(Channel, NoteData);		// // //
 	CFamiTrackerDoc *pDoc = GetDocument();		// // //
 	if (Channel < static_cast<unsigned>(pDoc->GetChannelCount())) {
@@ -2247,7 +2247,7 @@ void CFamiTrackerView::HaltNoteSingle(unsigned int Channel) const
 
 	NoteData.Note = HALT;
 	NoteData.Instrument = GetInstrument();
-	
+
 	SplitAdjustChannel(Channel, NoteData);		// // // ?
 	CFamiTrackerDoc *pDoc = GetDocument();		// // //
 	if (Channel < static_cast<unsigned>(pDoc->GetChannelCount())) {
@@ -2298,7 +2298,7 @@ void CFamiTrackerView::TriggerMIDINote(unsigned int Channel, unsigned int MidiNo
 			Velocity = m_iLastVolume * 8;
 		}
 	}
-	
+
 	if (!(theApp.IsPlaying() && m_bEditEnable && !m_bFollowMode))		// // //
 		PlayNote(Channel, Note, Octave, Velocity);
 
@@ -2327,7 +2327,7 @@ void CFamiTrackerView::TriggerMIDINote(unsigned int Channel, unsigned int MidiNo
 void CFamiTrackerView::CutMIDINote(unsigned int Channel, unsigned int MidiNote, bool InsertCut)
 {
 	CFamiTrackerDoc *pDoc = GetDocument();
-	
+
 	if (MidiNote >= NOTE_COUNT) MidiNote = NOTE_COUNT - 1;		// // //
 
 	// Cut a MIDI note
@@ -2364,7 +2364,7 @@ void CFamiTrackerView::CutMIDINote(unsigned int Channel, unsigned int MidiNote, 
 void CFamiTrackerView::ReleaseMIDINote(unsigned int Channel, unsigned int MidiNote, bool InsertCut)
 {
 	CFamiTrackerDoc *pDoc = GetDocument();
-	
+
 	if (MidiNote >= NOTE_COUNT) MidiNote = NOTE_COUNT - 1;		// // //
 
 	// Release a MIDI note
@@ -2484,7 +2484,7 @@ bool CFamiTrackerView::IsControlPressed() const
 
 // OnKeyDown accepts virtual keycodes, and handles most input.
 void CFamiTrackerView::OnKeyDown(UINT key, UINT nRepCnt, UINT nFlags)
-{	
+{
 	// Called when a key is pressed
 	if (GetFocus() != this)
 		return;
@@ -2779,7 +2779,7 @@ void CFamiTrackerView::KeyDecreaseAction()
 {
 	if (!m_bEditEnable)		// // //
 		return;
-	
+
 	AddAction(new CPActionScrollField {-1});		// // //
 }
 
@@ -2885,7 +2885,7 @@ bool CFamiTrackerView::EditVolumeColumn(stChanNote &Note, Keycode Key, bool &bSt
 	}
 
 	int Value = ConvertKeyToHex(Key);
-	
+
 	if (Value == -1 && theApp.GetSettings()->General.bHexKeypad)		// // //
 		Value = ConvertKeyExtra(Key);
 	if (Value == -1)
@@ -2973,11 +2973,11 @@ bool CFamiTrackerView::EditEffNumberColumn(stChanNote &Note, Input input, int Ef
 		Note.EffNumber[EffectIndex] = Effect;
 		if (m_bEditEnable && Note.EffNumber[EffectIndex] != EF_NONE)		// // //
 			GetParentFrame()->SetMessageText(GetEffectHint(Note, EffectIndex));
-		
+
 		if (prev == EF_NONE || effects[Effect].uiDefault != 0) {
 			Note.EffParam[EffectIndex] = effects[Effect].uiDefault;
 		}
-		
+
 		switch (EditStyle) {
 			case EDIT_STYLE_MPT:	// Modplug
 				if (Effect == m_iLastEffect)
@@ -3020,7 +3020,7 @@ bool CFamiTrackerView::EditEffParamColumn(stChanNote &Note, Keycode Key, int Eff
 			bStepDown = true;
 		return true;
 	}
-	
+
 	if (Value == -1 && theApp.GetSettings()->General.bHexKeypad)		// // //
 		Value = ConvertKeyExtra(Key);
 	if (Value == -1)
@@ -3035,7 +3035,7 @@ bool CFamiTrackerView::EditEffParamColumn(stChanNote &Note, Keycode Key, int Eff
 		Mask = 0xF0;
 		Shift = 0;
 	}
-	
+
 	switch (EditStyle) {
 		case EDIT_STYLE_FT2:	// FT2
 			Note.EffParam[EffectIndex] = (Note.EffParam[EffectIndex] & Mask) | Value << Shift;
@@ -3058,7 +3058,7 @@ bool CFamiTrackerView::EditEffParamColumn(stChanNote &Note, Keycode Key, int Eff
 			bStepDown = true;
 			break;
 	}
-	
+
 	m_iLastEffect = Note.EffNumber[EffectIndex];		// // //
 	m_iLastEffectParam = Note.EffParam[EffectIndex];
 
@@ -3231,15 +3231,15 @@ bool CFamiTrackerView::DoRelease() const
 	return pInstrument->CanRelease();
 }
 
-void CFamiTrackerView::HandleKeyboardNote(Keycode key, bool Pressed) 
+void CFamiTrackerView::HandleKeyboardNote(Keycode key, bool Pressed)
 {
 	if (theApp.GetAccelerator()->IsKeyUsed(static_cast<int>(key))) return;		// // //
 
 	// Play a note from the keyboard
 	int Note = TranslateKey(key);
 	int Channel = m_pPatternEditor->GetChannel();
-	
-	if (Pressed) {	
+
+	if (Pressed) {
 		static int LastNote;
 
 		if (CheckHaltKey(key)) {
@@ -3277,7 +3277,7 @@ void CFamiTrackerView::HandleKeyboardNote(Keycode key, bool Pressed)
 			// Find if note release should be used
 			// TODO: make this an option instead?
 			if (DoRelease())
-				ReleaseMIDINote(Channel, Note, false);	
+				ReleaseMIDINote(Channel, Note, false);
 			else
 				CutMIDINote(Channel, Note, false);
 			auto it = m_iNoteCorrection.find(key);		// // //
@@ -3553,7 +3553,7 @@ int CFamiTrackerView::TranslateKey(Keycode Key) const
 	// For modplug users
 	if (theApp.GetSettings()->General.iEditStyle == EDIT_STYLE_MPT)
 		return TranslateKeyModplug(Key);
-	
+
 	// For FastTracker 2 JP106 users
 	if (theApp.GetSettings()->General.iEditStyle == EDIT_STYLE_FT2_JP)
 		return TranslateKeyFT2JP(Key);
@@ -3593,7 +3593,7 @@ bool CFamiTrackerView::PreviewNote(Keycode Key)
 	TRACE("View: Note preview\n");
 
 	if (Note > 0) {
-		TriggerMIDINote(m_pPatternEditor->GetChannel(), Note, 0x7F, false); 
+		TriggerMIDINote(m_pPatternEditor->GetChannel(), Note, 0x7F, false);
 		return true;
 	}
 
@@ -3609,7 +3609,7 @@ void CFamiTrackerView::PreviewRelease(Keycode Key)
 	if (Note > 0) {
 		if (DoRelease())
 			ReleaseMIDINote(m_pPatternEditor->GetChannel(), Note, false);
-		else 
+		else
 			CutMIDINote(m_pPatternEditor->GetChannel(), Note, false);
 	}
 }
@@ -3654,8 +3654,8 @@ void CFamiTrackerView::TranslateMidiMessage()
 		switch (Message) {
 			case MIDI_MSG_NOTE_ON:
 				TriggerMIDINote(Channel, Data1, Data2, true);
-				AfxFormatString3(Status, IDS_MIDI_MESSAGE_ON_FORMAT, 
-					MakeIntString(Data1 % 12), 
+				AfxFormatString3(Status, IDS_MIDI_MESSAGE_ON_FORMAT,
+					MakeIntString(Data1 % 12),
 					MakeIntString(Data1 / 12),
 					MakeIntString(Data2));
 				break;
@@ -3668,8 +3668,8 @@ void CFamiTrackerView::TranslateMidiMessage()
 					CutMIDINote(Channel, Data1, false);
 				Status.Format(IDS_MIDI_MESSAGE_OFF);
 				break;
-			
-			case MIDI_MSG_PITCH_WHEEL: 
+
+			case MIDI_MSG_PITCH_WHEEL:
 				{
 					CTrackerChannel *pChannel = pDoc->GetChannel(Channel);
 					int PitchValue = 0x2000 - ((Data1 & 0x7F) | ((Data2 & 0x7F) << 7));
@@ -3808,8 +3808,8 @@ void CFamiTrackerView::OnDecreaseStepSize()
 		SetStepping(m_iInsertKeyStepping - 1);
 }
 
-void CFamiTrackerView::SetStepping(int Step) 
-{ 
+void CFamiTrackerView::SetStepping(int Step)
+{
 	m_iInsertKeyStepping = Step;
 	static_cast<CMainFrame*>(GetParentFrame())->UpdateControls();
 }
@@ -3883,7 +3883,7 @@ void CFamiTrackerView::OnOneStepDown()
 
 void CFamiTrackerView::MakeSilent()
 {
-	m_iAutoArpPtr		= 0; 
+	m_iAutoArpPtr		= 0;
 	m_iLastAutoArpPtr	= 0;
 	m_iAutoArpKeyCount	= 0;
 
@@ -3925,7 +3925,7 @@ void CFamiTrackerView::OnPickupRow()
 	int Frame = m_pPatternEditor->GetFrame();
 	int Row = m_pPatternEditor->GetRow();
 	int Channel = m_pPatternEditor->GetChannel();
-	
+
 	stChanNote Note;
 
 	pDoc->GetNoteData(Track, Frame, Channel, Row, &Note);
@@ -4010,7 +4010,7 @@ void CFamiTrackerView::OnDragLeave()
 		m_pPatternEditor->EndDrag();
 		InvalidateCursor();
 	}
-	
+
 	m_nDropEffect = DROPEFFECT_NONE;
 
 	CView::OnDragLeave();
@@ -4046,7 +4046,7 @@ BOOL CFamiTrackerView::OnDrop(COleDataObject* pDataObject, DROPEFFECT dropEffect
 		CPatternClipData *pClipData = new CPatternClipData();
 		HGLOBAL hMem = pDataObject->GetGlobalData(mClipboardFormat);
 		pClipData->FromMem(hMem);
-				
+
 		// Paste into pattern
 		if (!m_pPatternEditor->PerformDrop(pClipData, bCopy, m_bDropMix)) {
 			SAFE_RELEASE(pClipData);
@@ -4059,7 +4059,7 @@ BOOL CFamiTrackerView::OnDrop(COleDataObject* pDataObject, DROPEFFECT dropEffect
 	}
 
 	m_nDropEffect = DROPEFFECT_NONE;
-	
+
 	return Result;
 }
 
@@ -4104,7 +4104,7 @@ void CFamiTrackerView::BeginDragData(int ChanOffset, int RowOffset)
 	::GlobalFree(hMem);
 }
 
-bool CFamiTrackerView::IsDragging() const 
+bool CFamiTrackerView::IsDragging() const
 {
 	return m_bDragSource;
 }

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -318,7 +318,7 @@ CFamiTrackerView::CFamiTrackerView() :
 
 	// Register this object in the sound generator
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
-	ASSERT_VALID(pSoundGen);
+	ASSERT(pSoundGen);
 
 	pSoundGen->AssignView(this);
 }

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -27,7 +27,7 @@
 
 // CFamiTrackerView, the document view class
 
-#include <afxmt.h>	// Include synchronization objects
+#include <mutex>
 #include <unordered_map>		// // //
 
 #include "PatternEditorTypes.h"		// // //
@@ -326,7 +326,7 @@ private:
 	bool				m_bDropped;								// Drop was performed on this window
 
 	// Thread synchronization
-	mutable CCriticalSection m_csDrawLock;						// Lock for DCs
+	mutable std::mutex m_csDrawLock;						// Lock for DCs
 
 // Operations
 public:

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -27,7 +27,10 @@
 
 // CFamiTrackerView, the document view class
 
+#include "rigtorp/SPSCQueue.h"
+#include "utils/handle_ptr.h"
 #include <mutex>
+#include <thread>
 #include <unordered_map>		// // //
 
 #include "PatternEditorTypes.h"		// // //
@@ -259,6 +262,17 @@ public:
 // View variables
 //
 private:
+	/// Receive thread handle.
+	std::thread m_ReceiveThread;
+	/// Set by audio thread after pushing to m_MessageQueue.
+	HandlePtr m_hQueueEvent;
+	/// Set by main thread ~CFamiTrackerView() to terminate m_ReceiveThread.
+	HandlePtr m_hQuitEvent;
+
+	/// Pushed by audio thread (CFamiTrackerView::PostQueueMessage()) and popped by
+	/// receive thread.
+	rigtorp::SPSCQueue<AudioMessage> m_MessageQueue;
+
 	// General
 	bool				m_bHasFocus;
 	UINT				mClipboardFormat;
@@ -346,6 +360,8 @@ public:
 protected:
 	DECLARE_MESSAGE_MAP()
 public:
+	bool PostAudioMessage(AudioMessageId message, WPARAM wParam = 0, LPARAM lParam = 0);
+
 	virtual void OnDraw(CDC* /*pDC*/);
 	virtual void CalcWindowRect(LPRECT lpClientRect, UINT nAdjustType = adjustBorder);
 	virtual void OnUpdate(CView* /*pSender*/, LPARAM /*lHint*/, CObject* /*pHint*/);

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -77,10 +77,10 @@ public:
 	void		 SelectFrame(unsigned int Frame);
 	void		 SelectRow(unsigned int Row);		// // //
 	void		 SelectChannel(unsigned int Channel);
-	 
+
 	unsigned int GetSelectedFrame() const;
 	unsigned int GetSelectedChannel() const;
-	unsigned int GetSelectedRow() const; 
+	unsigned int GetSelectedRow() const;
 
 	void		 SetFollowMode(bool Mode);
 	bool		 GetFollowMode() const;
@@ -153,7 +153,7 @@ private:
 
 	// Drawing
 	void	UpdateMeters();
-	
+
 	void	InvalidateCursor();
 	void	InvalidateHeader();
 	void	InvalidatePatternEditor();
@@ -163,7 +163,7 @@ private:
 	void	RedrawFrameEditor();
 
 	void	PeriodicUpdate();
-	
+
 	int		TimerDelayer; // Refresh rate depending on playback
 
 	// Instruments
@@ -194,12 +194,12 @@ private:
 	// Input handling
 	void	KeyIncreaseAction();
 	void	KeyDecreaseAction();
-	
+
 	int		TranslateKey(Keycode Key) const;
 	int		TranslateKeyDefault(Keycode Key) const;
 	int		TranslateKeyModplug(Keycode Key) const;
 	int		TranslateKeyFT2JP(Keycode Key) const;
-	
+
 	bool	CheckClearKey(Keycode Key) const;
 	bool	CheckHaltKey(Keycode Key) const;
 	bool	CheckReleaseKey(Keycode Key) const;
@@ -232,10 +232,10 @@ private:
 	void	ReleaseNote(unsigned int Channel, unsigned int Note, unsigned int Octave) const;		// // //
 	void	HaltNote(unsigned int Channel, unsigned int Note, unsigned int Octave) const;		// // //
 	void	HaltNoteSingle(unsigned int Channel) const;		// // //
-	
+
 	void	UpdateArpDisplay();
 	void	UpdateNoteQueues();		// // //
-	
+
 	// Mute methods
 	bool	IsChannelSolo(unsigned int Channel) const;
 	bool	IsChipSolo(unsigned int Chip) const;		// // //

--- a/Source/FamiTrackerViewMessage.h
+++ b/Source/FamiTrackerViewMessage.h
@@ -30,10 +30,10 @@
 // Custom window messages for CFamiTrackerView
 enum {
 	WM_USER_PLAYER = WM_USER,		// Pattern play row has changed
-	WM_USER_MIDI_EVENT,				// There is a new MIDI command	
+	WM_USER_MIDI_EVENT,				// There is a new MIDI command
 	WM_USER_NOTE_EVENT,				// There is a new note command (by player)
 	WM_USER_DUMP_INST,				// // // End of track, add instrument
-	
+
 	WM_USER_ERROR,  // audio thread error, (nIDPrompt, nType)
 	/*
 	Previously the audio thread would call AfxMessageBox upon errors. The resulting

--- a/Source/FamiTrackerViewMessage.h
+++ b/Source/FamiTrackerViewMessage.h
@@ -29,12 +29,18 @@
 
 // Custom window messages for CFamiTrackerView
 enum {
-	WM_USER_PLAYER = WM_USER,		// Pattern play row has changed
-	WM_USER_MIDI_EVENT,				// There is a new MIDI command
-	WM_USER_NOTE_EVENT,				// There is a new note command (by player)
-	WM_USER_DUMP_INST,				// // // End of track, add instrument
+	WM_USER_MIDI_EVENT = WM_USER,				// There is a new MIDI command
+	WM_USER_GUI_COUNT,
+};
 
-	WM_USER_ERROR,  // audio thread error, (nIDPrompt, nType)
+/// Sent from audio to GUI thread. Only pass into CFamiTrackerView::PostQueueMessage()
+/// to avoid blocking the audio thread!
+enum AudioMessageId {
+	AM_PLAYER = WM_USER_GUI_COUNT,  // Pattern play row has changed
+	AM_NOTE_EVENT,  // There is a new note command (by player)
+	AM_DUMP_INST,  // // // End of track, add instrument
+
+	AM_ERROR,  // audio thread error, (nIDPrompt, nType)
 	/*
 	Previously the audio thread would call AfxMessageBox upon errors. The resulting
 	message boxes would often appear under the main window.
@@ -49,4 +55,10 @@ enum {
 	main thread to call CFamiTrackerView::OnAudioThreadError(), which calls
 	AfxMessageBox(nIDPrompt, nType).
 	*/
+};
+
+struct AudioMessage {
+	AudioMessageId message;
+	WPARAM wParam;
+	LPARAM lParam;
 };

--- a/Source/InstrumentRecorder.cpp
+++ b/Source/InstrumentRecorder.cpp
@@ -89,11 +89,11 @@ void CInstrumentRecorder::RecordInstrument(const unsigned Tick, CView *pView)		/
 	int Pos = (Tick - 1) % Intv;
 
 	signed char Val = 0;
-	
+
 	int PitchReg = 0;
 	int Detune = 0x7FFFFFFF;
 	int ID = m_iRecordChannel;
-	
+
 	char Chip = m_pDocument->GetChannel(m_pDocument->GetChannelIndex(m_iRecordChannel))->GetChip();
 	const auto REG = [&] (int x) { return m_pSoundGen->GetReg(Chip, x); };
 
@@ -239,7 +239,7 @@ void CInstrumentRecorder::RecordInstrument(const unsigned Tick, CView *pView)		/
 			m_pSequenceCache[k]->SetItem(Pos, Val);
 		}
 	}
-	
+
 	if (!(Tick % Intv))
 		FinalizeRecordInstrument();
 }
@@ -332,7 +332,7 @@ void CInstrumentRecorder::InitRecordInstrument()
 	CString str;
 	str.Format(_T("from %s"), pChan->GetChannelName());
 	(*m_pDumpInstrument)->SetName(str);
-	
+
 	if (Type == INST_FDS) {
 		m_pSequenceCache[SEQ_ARPEGGIO]->SetSetting(SETTING_ARP_FIXED);
 		return;

--- a/Source/InstrumentRecorder.cpp
+++ b/Source/InstrumentRecorder.cpp
@@ -25,6 +25,7 @@
 #include "stdafx.h"
 #include "InstrumentManager.h"
 #include "FamiTrackerDoc.h"
+#include "FamiTrackerView.h"
 #include "TrackerChannel.h"
 #include "FamiTrackerViewMessage.h"
 #include "SoundGen.h"
@@ -67,20 +68,20 @@ void CInstrumentRecorder::StartRecording()
 	InitRecordInstrument();
 }
 
-void CInstrumentRecorder::StopRecording(CView *pView)
+void CInstrumentRecorder::StopRecording(CFamiTrackerView *pView)
 {
 	if (*m_pDumpInstrument != nullptr && pView != nullptr)
-		pView->PostMessage(WM_USER_DUMP_INST);
+		pView->PostAudioMessage(AM_DUMP_INST);
 	--m_iDumpCount;
 }
 
-void CInstrumentRecorder::RecordInstrument(const unsigned Tick, CView *pView)		// // //
+void CInstrumentRecorder::RecordInstrument(const unsigned Tick, CFamiTrackerView *pView)		// // //
 {
 	unsigned int Intv = static_cast<unsigned>(m_stRecordSetting.Interval);
 	if (m_iRecordChannel == -1 || Tick > Intv * m_stRecordSetting.InstCount + 1) return;
 	if (Tick % Intv == 1 && Tick > Intv) {
 		if (*m_pDumpInstrument != nullptr && pView != nullptr) {
-			pView->PostMessage(WM_USER_DUMP_INST);
+			pView->PostAudioMessage(AM_DUMP_INST);
 			m_pDumpInstrument++;
 		}
 		--m_iDumpCount;

--- a/Source/InstrumentRecorder.h
+++ b/Source/InstrumentRecorder.h
@@ -30,6 +30,7 @@
 class CSequence;
 class CInstrument;
 class CFamiTrackerDoc;
+class CFamiTrackerView;
 class CSoundGen;
 
 struct stRecordSetting {
@@ -46,8 +47,8 @@ public:
 
 public:
 	void			StartRecording();
-	void			StopRecording(CView *pView);
-	void			RecordInstrument(const unsigned Tick, CView *pView);
+	void			StopRecording(CFamiTrackerView *pView);
+	void			RecordInstrument(const unsigned Tick, CFamiTrackerView *pView);
 
 	CInstrument		*GetRecordInstrument(unsigned Tick) const;
 	int				GetRecordChannel() const;

--- a/Source/MIDI.cpp
+++ b/Source/MIDI.cpp
@@ -59,8 +59,7 @@ CMIDI::CMIDI() :
 	m_bInStarted(false), 
 	m_iInDevice(0),
 	m_iOutDevice(0),
-	m_iQueueHead(0), 
-	m_iQueueTail(0),
+	m_MidiQueue(MAX_QUEUE),
 	m_hMIDIIn(NULL),
 	m_hMIDIOut(NULL),
 	m_iTimingCounter(0)
@@ -144,9 +143,9 @@ bool CMIDI::OpenDevices(void)
 		midiOutReset(m_hMIDIOut);
 	}
 
-	m_csQueue.Lock();
-	m_iQueueHead = m_iQueueTail = 0;
-	m_csQueue.Unlock();
+	while (m_MidiQueue.front()) {
+		m_MidiQueue.pop();
+	}
 
 	return true;
 }
@@ -214,17 +213,14 @@ void CMIDI::SetOutputDevice(int Device)
 
 void CMIDI::Enqueue(unsigned char MsgType, unsigned char MsgChannel, unsigned char Data1, unsigned char Data2)
 {
-	m_csQueue.Lock();
-	
-	m_iMsgTypeQueue[m_iQueueHead] = MsgType;
-	m_iMsgChanQueue[m_iQueueHead] = MsgChannel;
-	m_iData1Queue[m_iQueueHead]   = Data1;
-	m_iData2Queue[m_iQueueHead]   = Data2;
-	m_iQuantization[m_iQueueHead] = m_iTimingCounter;
-
-	m_iQueueHead = (m_iQueueHead + 1) % MAX_QUEUE;
-
-	m_csQueue.Unlock();
+	// Ehh, dropped events are fine I guess...
+	(void) m_MidiQueue.try_push(MidiMessage{
+		(char)MsgType,
+		(char)MsgChannel,
+		(char)Data1,
+		(char)Data2,
+		(char)m_iTimingCounter,
+	});
 }
 
 void CMIDI::Event(unsigned char Status, unsigned char Data1, unsigned char Data2)
@@ -270,21 +266,16 @@ bool CMIDI::ReadMessage(unsigned char & Message, unsigned char & Channel, unsign
 {
 	bool Result = false;
 	
-	m_csQueue.Lock();
-
-	if (m_iQueueHead != m_iQueueTail) {
+	if (auto MidiMessage = m_MidiQueue.front()) {
+		m_MidiQueue.pop();
 		Result = true;
 
-		Message = m_iMsgTypeQueue[m_iQueueTail];
-		Channel = m_iMsgChanQueue[m_iQueueTail];
-		Data1	= m_iData1Queue[m_iQueueTail];
-		Data2	= m_iData2Queue[m_iQueueTail];
-		m_iQuant = m_iQuantization[m_iQueueTail];
-
-		m_iQueueTail = (m_iQueueTail + 1) % MAX_QUEUE;
+		Message = MidiMessage->MsgType;
+		Channel = MidiMessage->MsgChan;
+		Data1	= MidiMessage->Data1;
+		Data2	= MidiMessage->Data2;
+		m_iQuant = MidiMessage->Quantization;
 	}
-
-	m_csQueue.Unlock();
 
 	return Result;
 }

--- a/Source/MIDI.h
+++ b/Source/MIDI.h
@@ -25,7 +25,7 @@
 #pragma once
 
 #include <mmsystem.h>
-#include <afxmt.h>
+#include "rigtorp/SPSCQueue.h"
 
 const int MIDI_MSG_NOTE_OFF			= 0x08;
 const int MIDI_MSG_NOTE_ON			= 0x09;
@@ -36,6 +36,14 @@ const int MIDI_MSG_CHANNEL_PRESSURE = 0x0D;
 const int MIDI_MSG_PITCH_WHEEL		= 0x0E;
 
 // CMIDI command target
+
+struct MidiMessage {
+	char MsgType;
+	char MsgChan;
+	char Data1;
+	char Data2;
+	char Quantization;
+};
 
 class CMIDI : public CObject
 {
@@ -96,14 +104,7 @@ private:
 	bool	m_bInStarted;
 
 	// MIDI queue
-	int		m_iQueueHead;
-	int		m_iQueueTail;
-
-	char	m_iMsgTypeQueue[MAX_QUEUE];
-	char	m_iMsgChanQueue[MAX_QUEUE];
-	char	m_iData1Queue[MAX_QUEUE];
-	char	m_iData2Queue[MAX_QUEUE];
-	char	m_iQuantization[MAX_QUEUE];
+	rigtorp::SPSCQueue<MidiMessage> m_MidiQueue;
 
 	int		m_iQuant;
 	int		m_iTimingCounter;
@@ -111,7 +112,4 @@ private:
 	// Device handles
 	HMIDIIN	 m_hMIDIIn;
 	HMIDIOUT m_hMIDIOut;
-
-	// Thread sync
-	CCriticalSection m_csQueue;
 };

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -75,7 +75,7 @@ static UINT indicators[] =
 {
 	ID_SEPARATOR,           // status line indicator
 	ID_INDICATOR_CHIP,
-	ID_INDICATOR_INSTRUMENT, 
+	ID_INDICATOR_INSTRUMENT,
 	ID_INDICATOR_OCTAVE,
 	ID_INDICATOR_RATE,
 	ID_INDICATOR_TEMPO,
@@ -88,8 +88,8 @@ static UINT indicators[] =
 
 // Timers
 enum {
-	TMR_WELCOME, 
-	TMR_AUDIO_CHECK, 
+	TMR_WELCOME,
+	TMR_AUDIO_CHECK,
 	TMR_AUTOSAVE
 };
 
@@ -103,8 +103,8 @@ IMPLEMENT_DYNCREATE(CMainFrame, CFrameWnd)
 
 // CMainFrame construction/destruction
 
-CMainFrame::CMainFrame() : 
-	m_pVisualizerWnd(NULL), 
+CMainFrame::CMainFrame() :
+	m_pVisualizerWnd(NULL),
 	m_pFrameEditor(NULL),
 	m_pGrooveDlg(NULL),			// // //
 	m_pFindDlg(NULL),			// // //
@@ -436,7 +436,7 @@ int CMainFrame::OnCreate(LPCREATESTRUCT lpCreateStruct)
 	EnableDocking(CBRS_ALIGN_ANY);
 	DockControlBar(&m_wndToolBar);
 	*/
-	
+
 	if (!CreateVisualizerWindow()) {
 		TRACE("Failed to create sample window\n");
 		return -1;      // fail to create
@@ -530,8 +530,8 @@ bool CMainFrame::CreateToolbars()
 	m_wndToolBarReBar.GetReBarCtrl().MinimizeBand(0);
 
 	HBITMAP hbm = (HBITMAP)::LoadImage(AfxGetInstanceHandle(), MAKEINTRESOURCE(IDB_TOOLBAR_256), IMAGE_BITMAP, DPI::SX(352), DPI::SY(16), LR_CREATEDIBSECTION);
-	m_bmToolbar.Attach(hbm); 
-	
+	m_bmToolbar.Attach(hbm);
+
 	m_ilToolBar.Create(DPI::SX(16), DPI::SY(16), ILC_COLOR8 | ILC_MASK, 4, 4);
 	m_ilToolBar.Add(&m_bmToolbar, RGB(192, 192, 192));
 	m_wndToolBar.GetToolBarCtrl().SetImageList(&m_ilToolBar);
@@ -573,7 +573,7 @@ bool CMainFrame::CreateDialogPanels()
 		TRACE("Failed to create pattern window\n");
 		return false;
 	}
-	
+
 	// // // Find / replace panel
 	m_pFindDlg = new CFindDlg();
 	if (!m_wndFindControlBar.Create(this, IDD_MAINBAR, CBRS_RIGHT | CBRS_TOOLTIPS | CBRS_FLYBY, IDD_MAINBAR)) {
@@ -593,7 +593,7 @@ bool CMainFrame::CreateDialogPanels()
 		TRACE("Failed to create dialog bar\n");
 		return false;
 	}
-	
+
 	m_wndDialogBar.ShowWindow(SW_SHOW);
 
 	// Subclass edit boxes
@@ -618,7 +618,7 @@ bool CMainFrame::CreateDialogPanels()
 	m_pButtonFixTempo->SubclassDlgItem(IDC_BUTTON_FIXTEMPO, &m_wndDialogBar);		// // //
 
 	// Subclass and setup the instrument list
-	
+
 	m_pInstrumentList = new CInstrumentList(this);
 	m_pInstrumentList->SubclassDlgItem(IDC_INSTRUMENTS, &m_wndDialogBar);
 
@@ -671,7 +671,7 @@ bool CMainFrame::CreateDialogPanels()
 	if (!m_wndFrameBar.Create(this, IDD_FRAMEBAR, CBRS_LEFT | CBRS_TOOLTIPS | CBRS_FLYBY, IDD_FRAMEBAR)) {
 		TRACE("Failed to create frame bar\n");
 	}
-	
+
 	m_wndFrameBar.ShowWindow(SW_SHOW);
 */
 
@@ -692,7 +692,7 @@ bool CMainFrame::CreateVisualizerWindow()
 
 	// Assign this to the sound generator
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
-	
+
 	if (pSoundGen)
 		pSoundGen->SetVisualizerWindow(m_pVisualizerWnd);
 
@@ -803,7 +803,7 @@ void CMainFrame::ResizeFrameWindow()
 	CRect ParentRect;
 	m_wndControlBar.GetClientRect(&ParentRect);
 	m_wndDialogBar.MoveWindow(DialogStartPos, DPI::SY(2), ParentRect.Width() - DialogStartPos, ParentRect.Height() - DPI::SY(4));		// // //
-	
+
 	CRect ControlRect;		// // //
 	m_wndDialogBar.GetDlgItem(IDC_MAINFRAME_INST_TOOLBAR)->GetWindowRect(&ControlRect);
 	GetDesktopWindow()->MapWindowPoints(&m_wndDialogBar, ControlRect);
@@ -859,7 +859,7 @@ void CMainFrame::SetRowCount(int Count)
 {
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
 	ASSERT_VALID(pDoc);
-	
+
 	if (!pDoc->IsFileLoaded())
 		return;
 
@@ -977,7 +977,7 @@ void CMainFrame::SelectInstrument(int Index)
 	//
 
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
-	
+
 	if (Index == -1)
 		return;
 
@@ -1261,10 +1261,10 @@ void CMainFrame::OnRemoveInstrument()
 	SelectInstrument(NewSelInst);
 }
 
-void CMainFrame::OnCloneInstrument() 
+void CMainFrame::OnCloneInstrument()
 {
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
-	
+
 	// No instruments in list
 	if (m_pInstrumentList->GetItemCount() == 0)
 		return;
@@ -1283,7 +1283,7 @@ void CMainFrame::OnCloneInstrument()
 void CMainFrame::OnDeepCloneInstrument()
 {
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
-	
+
 	// No instruments in list
 	if (m_pInstrumentList->GetItemCount() == 0)
 		return;
@@ -1333,7 +1333,7 @@ void CMainFrame::OnLoadInstrument()
 		SelectInstrument(Index);		// // //
 		m_pInstrumentList->InsertInstrument(Index);
 	}
-	
+
 	if (FileDialog.GetFileName().GetLength() == 0)		// // //
 		theApp.GetSettings()->SetPath(FileDialog.GetPathName() + _T("\\"), PATH_FTI);
 	else
@@ -1605,7 +1605,7 @@ void CMainFrame::OnUpdateSBInstrument(CCmdUI *pCmdUI)
 	}
 	CString msg;
 	AfxFormatString1(msg, ID_INDICATOR_INSTRUMENT, String);
-	pCmdUI->Enable(); 
+	pCmdUI->Enable();
 	pCmdUI->SetText(msg);
 }
 
@@ -1613,7 +1613,7 @@ void CMainFrame::OnUpdateSBOctave(CCmdUI *pCmdUI)
 {
 	CString String;
 	AfxFormatString1(String, ID_INDICATOR_OCTAVE, MakeIntString(GetSelectedOctave()));		// // //
-	pCmdUI->Enable(); 
+	pCmdUI->Enable();
 	pCmdUI->SetText(String);
 }
 
@@ -1629,7 +1629,7 @@ void CMainFrame::OnUpdateSBFrequency(CCmdUI *pCmdUI)
 
 	String.Format(_T("%i Hz"), EngineSpeed);
 
-	pCmdUI->Enable(); 
+	pCmdUI->Enable();
 	pCmdUI->SetText(String);
 }
 
@@ -1649,7 +1649,7 @@ void CMainFrame::OnUpdateSBTempo(CCmdUI *pCmdUI)
 void CMainFrame::OnUpdateSBChip(CCmdUI *pCmdUI)
 {
 	CString String;
-	
+
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
 	int Chip = pDoc->GetExpansionChip();
 
@@ -1700,7 +1700,7 @@ void CMainFrame::OnUpdateSBChip(CCmdUI *pCmdUI)
 		String.Delete(0, 3);
 	}
 
-	pCmdUI->Enable(); 
+	pCmdUI->Enable();
 	pCmdUI->SetText(String);
 }
 
@@ -1830,7 +1830,7 @@ void CMainFrame::OnUpdateSpeedEdit(CCmdUI *pCmdUI)
 		else {
 			pCmdUI->SetText(MakeIntString(static_cast<CFamiTrackerDoc*>(GetActiveDocument())->GetSongSpeed(m_iTrack)));
 		}
-	}	
+	}
 }
 
 void CMainFrame::OnUpdateTempoEdit(CCmdUI *pCmdUI)
@@ -1922,7 +1922,7 @@ void CMainFrame::OnFileGeneralsettings()
 	TabMixer.m_psp.dwFlags		&= ~PSP_HASHELP;
 	TabEmulation.m_psp.dwFlags	&= ~PSP_HASHELP;
 	TabGUI.m_psp.dwFlags		&= ~PSP_HASHELP;
-	
+
 	ConfigWindow.AddPage(&TabGeneral);
 	ConfigWindow.AddPage(&TabVersion);
 	ConfigWindow.AddPage(&TabAppearance);
@@ -2032,7 +2032,7 @@ void CMainFrame::OnUpdateKeyRepeat(CCmdUI *pCmdUI)
 
 void CMainFrame::OnFileImportText()
 {
-	CString fileFilter = LoadDefaultFilter(IDS_FILTER_TXT, _T(".txt"));		
+	CString fileFilter = LoadDefaultFilter(IDS_FILTER_TXT, _T(".txt"));
 	CFileDialog FileDialog(TRUE, 0, 0, OFN_HIDEREADONLY, fileFilter);
 
 	if (GetActiveDocument()->SaveModified() == 0)
@@ -2043,7 +2043,7 @@ void CMainFrame::OnFileImportText()
 
 	CTextExport Exporter;
 	CFamiTrackerDoc	*pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
-	
+
 	CString sResult;		// // //
 	do sResult = Exporter.ImportFile(FileDialog.GetPathName(), pDoc);
 	while (sResult == _T("Retry"));
@@ -2560,7 +2560,7 @@ void CMainFrame::OnDestroy()
 	TRACE("FrameWnd: Destroying main frame window\n");
 
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
-	
+
 	KillTimer(TMR_AUDIO_CHECK);
 
 	// Clean up sound stuff
@@ -2597,7 +2597,7 @@ void CMainFrame::SelectTrack(unsigned int Track)
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
 	CComboBox *pTrackBox = static_cast<CComboBox*>(m_wndDialogBar.GetDlgItem(IDC_SUBTUNE));
 	CFamiTrackerView *pView = static_cast<CFamiTrackerView*>(GetActiveView());
-	
+
 	m_iTrack = Track;
 
 	if (theApp.IsPlaying() && Track != theApp.GetSoundGenerator()->GetPlayerTrack())		// // // 050B
@@ -2633,7 +2633,7 @@ void CMainFrame::SelectOctave(int Octave)		// // // 050B
 BOOL CMainFrame::OnNotify(WPARAM wParam, LPARAM lParam, LRESULT* pResult)
 {
 	LPNMTOOLBAR lpnmtb = (LPNMTOOLBAR) lParam;
-	
+
 	// Handle new instrument menu
 	switch (((LPNMHDR)lParam)->code) {
 		case TBN_DROPDOWN:
@@ -2660,7 +2660,7 @@ void CMainFrame::OnNewInstrumentMenu(NMHDR* pNotifyStruct, LRESULT* result)
 
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
 	CFamiTrackerView *pView = static_cast<CFamiTrackerView*>(GetActiveView());
-	
+
 	int Chip = pDoc->GetExpansionChip();
 	int SelectedChip = pDoc->GetChannel(pView->GetSelectedChannel())->GetChip();	// where the cursor is located
 
@@ -2702,7 +2702,7 @@ void CMainFrame::OnNewInstrumentMenu(NMHDR* pNotifyStruct, LRESULT* result)
 			menu.SetDefaultItem(ID_INSTRUMENT_ADD_S5B);
 			break;
 	}
-	
+
 	menu.TrackPopupMenu(TPM_LEFTALIGN | TPM_RIGHTBUTTON, rect.left, rect.bottom, this);
 }
 
@@ -2738,7 +2738,7 @@ void CMainFrame::OnLoadInstrumentMenu(NMHDR * pNotifyStruct, LRESULT * result)
 
 		if (Index == -1)
 			return;
-		
+
 		SelectInstrument(Index);
 		m_pInstrumentList->InsertInstrument(Index);
 	}
@@ -2746,7 +2746,7 @@ void CMainFrame::OnLoadInstrumentMenu(NMHDR * pNotifyStruct, LRESULT * result)
 
 void CMainFrame::SelectInstrumentFolder()
 {
-	BROWSEINFOA Browse;	
+	BROWSEINFOA Browse;
 	LPITEMIDLIST lpID;
 	char Path[MAX_PATH];
 	CString Title;
@@ -2795,7 +2795,7 @@ BOOL CMainFrame::OnCopyData(CWnd* pWnd, COPYDATASTRUCT* pCopyDataStruct)
 bool CMainFrame::AddAction(Action *pAction)
 {
 	ASSERT(m_history != NULL);
-	
+
 	pAction->SaveUndoState(this);
 
 	// Save state before operation. (Pasting also moves selection :( )
@@ -3250,7 +3250,7 @@ void CMainFrame::SetControlPanelPosition(control_panel_pos_t Position)		// // //
 	m_iControlPanelPos = Position;
 	if (m_iControlPanelPos)
 		SetFrameEditorPosition(FRAME_EDIT_POS_LEFT);
-	
+
 	/*
 	CRect Rect {193, 0, 193, 126};
 	MapDialogRect(m_wndInstToolBarWnd, &Rect);
@@ -3301,10 +3301,10 @@ void CMainFrame::OnToggleSpeed()
 {
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
 	int Speed = pDoc->GetSpeedSplitPoint();
-	
-	if (Speed == DEFAULT_SPEED_SPLIT_POINT) 
+
+	if (Speed == DEFAULT_SPEED_SPLIT_POINT)
 		Speed = OLD_SPEED_SPLIT_POINT;
-	else 
+	else
 		Speed = DEFAULT_SPEED_SPLIT_POINT;
 
 	pDoc->SetSpeedSplitPoint(Speed);
@@ -3318,7 +3318,7 @@ void CMainFrame::OnUpdateFrameTitle(BOOL bAddToTitle)
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
 
 	CString title = pDoc->GetTitle();
-	
+
 	// Add a star (*) for unsaved documents
 	if (pDoc->IsModified())
 		title.Append(_T("*"));
@@ -3351,7 +3351,7 @@ void CMainFrame::CheckAudioStatus()
 	// TODO remove static variables
 	static BOOL DisplayedError;
 	static DWORD MessageTimeout;
-	
+
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
 
 	if (pSoundGen == NULL) {
@@ -3550,7 +3550,7 @@ void CMainFrame::OnEditRemoveUnusedSamples()
 
 	if (AfxMessageBox(IDS_REMOVE_SAMPLES, MB_YESNO | MB_ICONWARNING | MB_DEFBUTTON2) == IDNO)
 		return;
-	
+
 	CloseInstrumentEditor();
 	pDoc->RemoveUnusedSamples();
 	ResetUndo();		// // //
@@ -3563,7 +3563,7 @@ void CMainFrame::OnEditPopulateUniquePatterns()		// // //
 
 	if (AfxMessageBox(IDS_POPULATE_PATTERNS, MB_YESNO | MB_ICONWARNING | MB_DEFBUTTON2) == IDNO)
 		return;
-	
+
 	pDoc->PopulateUniquePatterns(m_iTrack);
 	ResetUndo();
 	pDoc->UpdateAllViews(NULL, UPDATE_FRAME);
@@ -3675,7 +3675,7 @@ void CMainFrame::OnUpdateSpeedDefault(CCmdUI *pCmdUI)
 void CMainFrame::OnUpdateSpeedCustom(CCmdUI *pCmdUI)
 {
 	CFamiTrackerDoc *pDoc = static_cast<CFamiTrackerDoc*>(GetActiveDocument());
-	ASSERT_VALID(pDoc);	
+	ASSERT_VALID(pDoc);
 
 	pCmdUI->Enable(!theApp.IsPlaying());		// // //
 	pCmdUI->SetCheck(pDoc->GetEngineSpeed() != 0);

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -67,10 +67,6 @@
 #include "DPI.h"		// // //
 #include "HistoryFileDlg.h"
 
-#ifdef _DEBUG
-#define new DEBUG_NEW
-#endif
-
 static UINT indicators[] =
 {
 	ID_SEPARATOR,           // status line indicator

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -2569,7 +2569,7 @@ void CMainFrame::OnDestroy()
 		pSoundGen->SetVisualizerWindow(NULL);
 		// Kill the sound interface since the main window is being destroyed
 		CEvent *pSoundEvent = new CEvent(FALSE, FALSE);
-		pSoundGen->PostThreadMessage(WM_USER_CLOSE_SOUND, (WPARAM)pSoundEvent, NULL);
+		pSoundGen->PostGuiMessage(WM_USER_CLOSE_SOUND, (WPARAM)pSoundEvent, NULL);
 		// Wait for sound to close
 		DWORD dwResult = ::WaitForSingleObject(pSoundEvent->m_hObject, CSoundGen::AUDIO_TIMEOUT + 1000);
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -781,7 +781,7 @@ bool CSoundGen::ResetAudioDevice()
 
 	// Reinitialize sound interface
 	if (!m_pSoundInterface->SetupDevice(Device)) {
-		m_pTrackerView->PostMessage(WM_USER_ERROR, IDS_SOUND_ERROR, MB_ICONERROR);
+		m_pTrackerView->PostAudioMessage(AM_ERROR, IDS_SOUND_ERROR, MB_ICONERROR);
 		return false;
 	}
 
@@ -796,7 +796,7 @@ bool CSoundGen::ResetAudioDevice()
 
 	// Channel failed
 	if (m_pSoundStream == NULL) {
-		m_pTrackerView->PostMessage(WM_USER_ERROR, IDS_SOUND_BUFFER_ERROR, MB_ICONERROR);
+		m_pTrackerView->PostAudioMessage(AM_ERROR, IDS_SOUND_BUFFER_ERROR, MB_ICONERROR);
 		return false;
 	}
 
@@ -1417,7 +1417,7 @@ void CSoundGen::HaltPlayer()
 
 	// Signal that playback has stopped
 	if (m_pTrackerView != NULL) {
-		m_pTrackerView->PostMessage(WM_USER_PLAYER, m_iPlayFrame, m_iPlayRow);
+		m_pTrackerView->PostAudioMessage(AM_PLAYER, m_iPlayFrame, m_iPlayRow);
 		m_pInstRecorder->StopRecording(m_pTrackerView);		// // //
 	}
 
@@ -1748,7 +1748,7 @@ void CSoundGen::CheckControl()
 	if (m_bDirty) {
 		m_bDirty = false;
 		if (!m_bRendering)
-			m_pTrackerView->PostMessage(WM_USER_PLAYER, m_iPlayFrame, m_iPlayRow);
+			m_pTrackerView->PostAudioMessage(AM_PLAYER, m_iPlayFrame, m_iPlayRow);
 	}
 }
 
@@ -1941,7 +1941,7 @@ bool CSoundGen::RenderToFile(LPTSTR pFile, render_end_t SongEndType, int SongEnd
 	// Unfortunately, destructor doesn't cleanup object. Only CloseFile() does.
 	if (!m_pWaveFile ||
 		!m_pWaveFile->OpenFile(pFile, theApp.GetSettings()->Sound.iSampleRate, theApp.GetSettings()->Sound.iSampleSize, 1)) {
-		m_pTrackerView->PostMessage(WM_USER_ERROR, IDS_FILE_OPEN_ERROR);
+		m_pTrackerView->PostAudioMessage(AM_ERROR, IDS_FILE_OPEN_ERROR);
 		return false;
 	}
 	else {
@@ -2436,7 +2436,7 @@ void CSoundGen::OnRemoveDocument(WPARAM wParam, LPARAM lParam)
 void CSoundGen::RegisterKeyState(int Channel, int Note)
 {
 	if (m_pTrackerView != NULL)
-		m_pTrackerView->PostMessage(WM_USER_NOTE_EVENT, Channel, Note);
+		m_pTrackerView->PostAudioMessage(AM_NOTE_EVENT, Channel, Note);
 }
 
 // FDS & N163

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -28,12 +28,7 @@
 // This thread will take care of the NES sound generation
 //
 
-// SPSCQueue uses placement new, which is broken by MFC's #define new DEBUG_NEW.
-#pragma push_macro("new")
-#undef new
 #include "rigtorp/SPSCQueue.h"
-#pragma pop_macro("new")
-
 #include <queue>		// // //
 #include "Common.h"
 

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -28,7 +28,6 @@
 // This thread will take care of the NES sound generation
 //
 
-#include <afxmt.h>		// Synchronization objects
 #include <queue>		// // //
 #include "Common.h"
 
@@ -322,7 +321,7 @@ private:
 	// Thread synchronization
 private:
 	mutable std::mutex m_csAPULock;		// // //
-	mutable CCriticalSection m_csVisualizerWndLock;
+	mutable std::mutex m_csVisualizerWndLock;
 
 	// Handles
 	HANDLE				m_hInterruptEvent;					// Used to interrupt sound buffer syncing

--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -392,6 +392,8 @@ bool CSoundStream::Play()
 	// while the low-latency stream plays.
 	DWORD taskIndex = 0;
 	if (m_hTask == nullptr) {
+		// AvSetMmThreadCharacteristicsW is unimplemented on Wine (prints fixme), but
+		// returns a handle anyway.
 		m_hTask = AvSetMmThreadCharacteristicsW(L"Pro Audio", &taskIndex);
 		TRACE("AvSetMmThreadCharacteristicsW success: %d", m_hTask != 0);
 	}

--- a/Source/SoundInterface.h
+++ b/Source/SoundInterface.h
@@ -29,19 +29,9 @@
 #include <memory>
 #include <wrl/client.h>
 #include "str_conv/str_conv.hpp"
+#include "utils/handle_ptr.h"
 
 using Microsoft::WRL::ComPtr;
-
-struct CloseHandleT {
-	void operator()(HANDLE handle) {
-		if (handle) {
-			CloseHandle(handle);
-		}
-	}
-};
-
-/// HANDLE is void*, so unique_ptr<void, CloseHandleT> is a RAII HANDLE.
-using HandlePtr = std::unique_ptr<void, CloseHandleT>;
 
 // Return values from CSoundStream::WaitForReady()
 enum class WaitResult {

--- a/Source/WavProgressDlg.cpp
+++ b/Source/WavProgressDlg.cpp
@@ -172,7 +172,7 @@ void CWavProgressDlg::OnCancel()
 
 	if (pSoundGen->IsRendering()) {
 		//pSoundGen->StopRendering();
-		pSoundGen->PostThreadMessage(WM_USER_STOP_RENDER, 0, 0);
+		pSoundGen->PostGuiMessage(WM_USER_STOP_RENDER, 0, 0);
 	}
 	CancelRender = true;
 

--- a/Source/WavProgressDlg.cpp
+++ b/Source/WavProgressDlg.cpp
@@ -77,7 +77,7 @@ BOOL CWavProgressDlg::OnInitDialog()
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
 
 	m_iTimerPeriod = theApp.GetSettings()->GUI.iLowRefreshRate;
-	
+
 	pView->Invalidate();
 	pView->RedrawWindow();
 
@@ -101,7 +101,7 @@ void CWavProgressDlg::OnTimer(UINT_PTR nIDEvent)
 	// Update progress status
 	CString Text;
 	DWORD Time = (GetTickCount() - m_dwStartTime) / 1000;
-	
+
 	CProgressCtrl *pProgressBar = static_cast<CProgressCtrl*>(GetDlgItem(IDC_PROGRESS_BAR));
 	CSoundGen *pSoundGen = theApp.GetSoundGenerator();
 

--- a/Source/rigtorp/SPSCQueue.h
+++ b/Source/rigtorp/SPSCQueue.h
@@ -1,0 +1,240 @@
+/*
+Copyright (c) 2020 Erik Rigtorp <erik@rigtorp.se>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <memory> // std::allocator
+#include <new>    // std::hardware_destructive_interference_size
+#include <stdexcept>
+#include <type_traits> // std::enable_if, std::is_*_constructible
+
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(nodiscard)
+#define RIGTORP_NODISCARD [[nodiscard]]
+#endif
+#endif
+#ifndef RIGTORP_NODISCARD
+#define RIGTORP_NODISCARD
+#endif
+
+namespace rigtorp {
+
+template <typename T, typename Allocator = std::allocator<T>> class SPSCQueue {
+
+#if defined(__cpp_if_constexpr) && defined(__cpp_lib_void_t)
+  template <typename Alloc2, typename = void>
+  struct has_allocate_at_least : std::false_type {};
+
+  template <typename Alloc2>
+  struct has_allocate_at_least<
+      Alloc2, std::void_t<typename Alloc2::value_type,
+                          decltype(std::declval<Alloc2 &>().allocate_at_least(
+                              size_t{}))>> : std::true_type {};
+#endif
+
+public:
+  explicit SPSCQueue(const size_t capacity,
+                     const Allocator &allocator = Allocator())
+      : capacity_(capacity), allocator_(allocator) {
+    // The queue needs at least one element
+    if (capacity_ < 1) {
+      capacity_ = 1;
+    }
+    capacity_++; // Needs one slack element
+    // Prevent overflowing size_t
+    if (capacity_ > SIZE_MAX - 2 * kPadding) {
+      capacity_ = SIZE_MAX - 2 * kPadding;
+    }
+
+#if defined(__cpp_if_constexpr) && defined(__cpp_lib_void_t)
+    if constexpr (has_allocate_at_least<Allocator>::value) {
+      auto res = allocator_.allocate_at_least(capacity_ + 2 * kPadding);
+      slots_ = res.ptr;
+      capacity_ = res.count - 2 * kPadding;
+    } else {
+      slots_ = std::allocator_traits<Allocator>::allocate(
+          allocator_, capacity_ + 2 * kPadding);
+    }
+#else
+    slots_ = std::allocator_traits<Allocator>::allocate(
+        allocator_, capacity_ + 2 * kPadding);
+#endif
+
+    static_assert(alignof(SPSCQueue<T>) == kCacheLineSize, "");
+    static_assert(sizeof(SPSCQueue<T>) >= 3 * kCacheLineSize, "");
+    assert(reinterpret_cast<char *>(&readIdx_) -
+               reinterpret_cast<char *>(&writeIdx_) >=
+           static_cast<std::ptrdiff_t>(kCacheLineSize));
+  }
+
+  ~SPSCQueue() {
+    while (front()) {
+      pop();
+    }
+    std::allocator_traits<Allocator>::deallocate(allocator_, slots_,
+                                                 capacity_ + 2 * kPadding);
+  }
+
+  // non-copyable and non-movable
+  SPSCQueue(const SPSCQueue &) = delete;
+  SPSCQueue &operator=(const SPSCQueue &) = delete;
+
+  template <typename... Args>
+  void emplace(Args &&...args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const writeIdx = writeIdx_.load(std::memory_order_relaxed);
+    auto nextWriteIdx = writeIdx + 1;
+    if (nextWriteIdx == capacity_) {
+      nextWriteIdx = 0;
+    }
+    while (nextWriteIdx == readIdxCache_) {
+      readIdxCache_ = readIdx_.load(std::memory_order_acquire);
+    }
+    new (&slots_[writeIdx + kPadding]) T(std::forward<Args>(args)...);
+    writeIdx_.store(nextWriteIdx, std::memory_order_release);
+  }
+
+  template <typename... Args>
+  RIGTORP_NODISCARD bool try_emplace(Args &&...args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const writeIdx = writeIdx_.load(std::memory_order_relaxed);
+    auto nextWriteIdx = writeIdx + 1;
+    if (nextWriteIdx == capacity_) {
+      nextWriteIdx = 0;
+    }
+    if (nextWriteIdx == readIdxCache_) {
+      readIdxCache_ = readIdx_.load(std::memory_order_acquire);
+      if (nextWriteIdx == readIdxCache_) {
+        return false;
+      }
+    }
+    new (&slots_[writeIdx + kPadding]) T(std::forward<Args>(args)...);
+    writeIdx_.store(nextWriteIdx, std::memory_order_release);
+    return true;
+  }
+
+  void push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  void push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    emplace(std::forward<P>(v));
+  }
+
+  RIGTORP_NODISCARD bool
+  try_push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    return try_emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  RIGTORP_NODISCARD bool
+  try_push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    return try_emplace(std::forward<P>(v));
+  }
+
+  RIGTORP_NODISCARD T *front() noexcept {
+    auto const readIdx = readIdx_.load(std::memory_order_relaxed);
+    if (readIdx == writeIdxCache_) {
+      writeIdxCache_ = writeIdx_.load(std::memory_order_acquire);
+      if (writeIdxCache_ == readIdx) {
+        return nullptr;
+      }
+    }
+    return &slots_[readIdx + kPadding];
+  }
+
+  void pop() noexcept {
+    static_assert(std::is_nothrow_destructible<T>::value,
+                  "T must be nothrow destructible");
+    auto const readIdx = readIdx_.load(std::memory_order_relaxed);
+    assert(writeIdx_.load(std::memory_order_acquire) != readIdx);
+    slots_[readIdx + kPadding].~T();
+    auto nextReadIdx = readIdx + 1;
+    if (nextReadIdx == capacity_) {
+      nextReadIdx = 0;
+    }
+    readIdx_.store(nextReadIdx, std::memory_order_release);
+  }
+
+  RIGTORP_NODISCARD size_t size() const noexcept {
+    std::ptrdiff_t diff = writeIdx_.load(std::memory_order_acquire) -
+                          readIdx_.load(std::memory_order_acquire);
+    if (diff < 0) {
+      diff += capacity_;
+    }
+    return static_cast<size_t>(diff);
+  }
+
+  RIGTORP_NODISCARD bool empty() const noexcept {
+    return writeIdx_.load(std::memory_order_acquire) ==
+           readIdx_.load(std::memory_order_acquire);
+  }
+
+  RIGTORP_NODISCARD size_t capacity() const noexcept { return capacity_ - 1; }
+
+private:
+#ifdef __cpp_lib_hardware_interference_size
+  static constexpr size_t kCacheLineSize =
+      std::hardware_destructive_interference_size;
+#else
+  static constexpr size_t kCacheLineSize = 64;
+#endif
+
+  // Padding to avoid false sharing between slots_ and adjacent allocations
+  static constexpr size_t kPadding = (kCacheLineSize - 1) / sizeof(T) + 1;
+
+private:
+  size_t capacity_;
+  T *slots_;
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(no_unique_address)
+  Allocator allocator_ [[no_unique_address]];
+#else
+  Allocator allocator_;
+#endif
+
+  // Align to cache line size in order to avoid false sharing
+  // readIdxCache_ and writeIdxCache_ is used to reduce the amount of cache
+  // coherency traffic
+  alignas(kCacheLineSize) std::atomic<size_t> writeIdx_ = {0};
+  alignas(kCacheLineSize) size_t readIdxCache_ = 0;
+  alignas(kCacheLineSize) std::atomic<size_t> readIdx_ = {0};
+  alignas(kCacheLineSize) size_t writeIdxCache_ = 0;
+
+  // Padding to avoid adjacent allocations to share cache line with
+  // writeIdxCache_
+  char padding_[kCacheLineSize - sizeof(writeIdxCache_)];
+};
+} // namespace rigtorp

--- a/Source/stdafx.h
+++ b/Source/stdafx.h
@@ -99,7 +99,6 @@
 #endif
 
 #ifdef _DEBUG
-#define new DEBUG_NEW
 template <typename... T>
 bool _trace(TCHAR *format, T... args)
 {

--- a/Source/utils/handle_ptr.h
+++ b/Source/utils/handle_ptr.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+#include <windef.h>
+
+struct CloseHandleT {
+	void operator()(HANDLE handle) {
+		if (handle) {
+			CloseHandle(handle);
+		}
+	}
+};
+
+/// HANDLE is void*, so unique_ptr<void, CloseHandleT> is a RAII HANDLE.
+using HandlePtr = std::unique_ptr<void, CloseHandleT>;

--- a/cmake/exe.cmake
+++ b/cmake/exe.cmake
@@ -83,6 +83,7 @@ add_executable(${exe}
         Source/resampler/resample.inl
         Source/resampler/sinc.cpp
         Source/resampler/sinc.hpp
+        Source/rigtorp/SPSCQueue.h
         Source/str_conv/str_conv.hpp
         Source/str_conv/utf8_conv.hpp
         Source/type_safe/arithmetic_policy.hpp

--- a/cmake/exe.cmake
+++ b/cmake/exe.cmake
@@ -160,6 +160,7 @@ add_executable(${exe}
         Source/drivers/drv_vrc7.h
         Source/utils/ftmath.cpp
         Source/utils/ftmath.h
+        Source/utils/handle_ptr.h
         Source/utils/input.h
         Source/utils/variadic_minmax.h
         Source/AboutDlg.cpp


### PR DESCRIPTION
This replaces all message queues between the audio and GUI thread with wait-free `rigtorp/SPSCQueue`s. The queue from audio to GUI is read by a worker thread owned by `CFamiTrackerView::m_ReceiveThread`, which then blocking-sends window messages to the main thread's event loop.

This eliminates the last known causes of audio stuttering (un/minimizing windows on Windows <=7 with compositing off, and enabling register view and switching windows on Wine kwin_x11), outside of Mac Wine. For the first time in this program's history, Dn-FamiTracker can run at a stable 20-22 ms of latency (eg. by setting the slider to 1ms), entirely immune to the inescapable audio glitching that has plagued it for years. (Technically the audio thread still competes with the main thread for mutexes, but this does not contend in practice.)

As an added bonus, this replaces the queue between the MIDI thread and the main thread with a `SPSCQueue` (eliminating janky custom code), though I didn't bother rewriting the "new event arrived" signaling system (`WM_USER_MIDI_EVENT`) with a SPSCQueue. This is no worse than before, but I wonder how `CMIDI::m_iTimingCounter` and row transitions interact, whether there are off-by-1-row bugs in this code or not, and if we can get more reliable timing by having `CMIDI` know about `CFamiTrackerView::PostQueueMessage`. (Perhaps timing doesn't matter if the main window is driven by the MIDI clock (not sure if always the case, see `CFamiTrackerView::TranslateMidiMessage()`), and if the main and MIDI threads hanging does not affect the time of MIDI events relative to the MIDI clock.)

- In `CMIDI::Event`, what happens when {C, static, reinterpret} casting `CView*` to `CFamiTrackerView*`, with the latter either visible or a forward declaration?

...

- [x] Swap AudioMessage and GuiMessage
- [x] Pick a better name for QueueMessage (intended as a noun, sounds like a verb) and SpscMessage (unpronounceable)
- [ ] Replacing `AudioMessageId` with `enum class` would make dispatch safer (no accidental audio thread blocking send `PostMessage`), and forwarding manageable, but the `ON_MESSAGE` recipient harder to use.

Fixes #134.