### PR TITLE
Fix crash when activating non-initial song then opening document with expansion chip(s)

### DIFF
--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -3383,11 +3383,13 @@ void CFamiTrackerDoc::SetEngineSpeed(unsigned int Speed)
 	SetExceededFlag();		// // //
 }
 
-void CFamiTrackerDoc::SetMachine(machine_t Machine)
+void CFamiTrackerDoc::SetMachine(machine_t Machine, bool Redraw)
 {
 	ASSERT(Machine == PAL || Machine == NTSC);
 	m_iMachine = Machine;
-	UpdateAllViews(NULL, UPDATE_PATTERN);
+	if (Redraw) {
+		UpdateAllViews(NULL, UPDATE_PATTERN);
+	}
 	SetModifiedFlag();
 	SetExceededFlag();		// // //
 }
@@ -4011,8 +4013,10 @@ void CFamiTrackerDoc::SetupChannels(unsigned char Chip)
 	// This will select a chip in the sound emulator
 
 	if (Chip != SNDCHIP_NONE) {
-		// Do not allow expansion chips in PAL mode
-		SetMachine(NTSC);
+		// Do not allow expansion chips in PAL mode.
+		// Do not redraw pattern editor since we're in the middle of loading document,
+		// and the program is in an inconsistent state.
+		SetMachine(NTSC, false);
 	}
 
 	// Store the chip
@@ -5153,7 +5157,9 @@ void CFamiTrackerDoc::MakeKraid()			// // // Easter Egg
 	SetTrackTitle(0, CPatternData::DEFAULT_TITLE);
 	m_pTracks[0]->ClearEverything();
 	SetEngineSpeed(0);
-	SetMachine(NTSC);
+	// Do not redraw pattern editor since we're in the middle of loading document,
+	// and the program is in an inconsistent state.
+	SetMachine(NTSC, false);
 	SetFrameCount(0, 14);
 	SetPatternLength(0, 24);
 	SetSongSpeed(0, 8);

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -206,7 +206,7 @@ public:
 
 	// Global (module) data
 	void			SetEngineSpeed(unsigned int Speed);
-	void			SetMachine(machine_t Machine);		// // //
+	void			SetMachine(machine_t Machine, bool Redraw);		// // //
 	machine_t		GetMachine() const		{ return m_iMachine; };		// // //
 	unsigned int	GetEngineSpeed() const	{ return m_iEngineSpeed; };
 	unsigned int	GetFrameRate() const;

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -3587,7 +3587,7 @@ void CMainFrame::OnTrackerPal()
 	ASSERT_VALID(pDoc);
 
 	machine_t Machine = PAL;
-	pDoc->SetMachine(Machine);
+	pDoc->SetMachine(Machine, true);
 	theApp.GetSoundGenerator()->LoadMachineSettings();		// // //
 	theApp.GetSoundGenerator()->DocumentPropertiesChanged(pDoc);		// // //
 	m_wndInstEdit.SetRefreshRate(static_cast<float>(pDoc->GetFrameRate()));		// // //
@@ -3599,7 +3599,7 @@ void CMainFrame::OnTrackerNtsc()
 	ASSERT_VALID(pDoc);
 
 	machine_t Machine = NTSC;
-	pDoc->SetMachine(Machine);
+	pDoc->SetMachine(Machine, true);
 	theApp.GetSoundGenerator()->LoadMachineSettings();		// // //
 	theApp.GetSoundGenerator()->DocumentPropertiesChanged(pDoc);		// // //
 	m_wndInstEdit.SetRefreshRate(static_cast<float>(pDoc->GetFrameRate()));		// // //

--- a/Source/TextExporter.cpp
+++ b/Source/TextExporter.cpp
@@ -716,7 +716,9 @@ const CString& CTextExport::ImportFile(LPCTSTR FileName, CFamiTrackerDoc *pDoc)
 				break;
 			case CT_MACHINE:
 				CHECK(t.ReadInt(i,0,PAL,&sResult));
-				pDoc->SetMachine(static_cast<machine_t>(i));
+				// Do not redraw pattern editor since we're in the middle of loading document,
+				// and the program is in an inconsistent state.
+				pDoc->SetMachine(static_cast<machine_t>(i), false);
 				CHECK(t.ReadEOL(&sResult));
 				break;
 			case CT_FRAMERATE:


### PR DESCRIPTION
`CFamiTrackerDoc::OpenDocumentNew()` and other functions can call `CFamiTrackerDoc::SetupChannels()`. If the new document contains expansion chips, it calls `CFamiTrackerDoc::SetMachine()` during the middle of updating the document. Previously this could call `CDocument::UpdateAllViews()` (a method which has no right to exist), trying to redraw the pattern editor mid-load, when the number of songs has already been reset to 1 but the active song/track is still unchanged. If you previously picked a non-initial song, `CPatternEditor::GetFrameCount()` calls `m_pDocument->GetFrameCount(GetSelectedTrack())`, which indexes out of bounds.

The "solution" is to add a boolean parameter to `CFamiTrackerDoc::SetMachine()`, to skip redrawing if the document is in an inconsistent state. I would not be surprised if there are other crashes lurking undiscovered.

Of course the real fix is to make observing inconsistent state difficult to impossible by design, by creating a StateTransaction-style type which reloads program state exactly once, after all changes have been made and the program is in a consistent state. But FamiTracker is too complex to rewrite state management entirely.

Fixes #147.