### PR TITLE
Fix mostly-theoretical data race when popping from SPSC queues

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -344,9 +344,10 @@ CFamiTrackerView::CFamiTrackerView() :
 			m_hQuitEvent.get(),
 		};
 		while (true) {
-			while (auto msg = m_MessageQueue.front()) {
+			while (auto pMsg = m_MessageQueue.front()) {
+				auto msg = *pMsg;
 				m_MessageQueue.pop();
-				PostMessage(msg->message, msg->wParam, msg->lParam);
+				PostMessage(msg.message, msg.wParam, msg.lParam);
 			}
 
 			if (WaitForMultipleObjects(2, events, FALSE, INFINITE) != WAIT_OBJECT_0) {

--- a/Source/MIDI.cpp
+++ b/Source/MIDI.cpp
@@ -55,8 +55,8 @@ void CALLBACK CMIDI::MidiInProc(HMIDIIN hMidiIn, UINT wMsg, DWORD dwInstance, DW
 
 // Instance stuff
 
-CMIDI::CMIDI() : 
-	m_bInStarted(false), 
+CMIDI::CMIDI() :
+	m_bInStarted(false),
 	m_iInDevice(0),
 	m_iOutDevice(0),
 	m_MidiQueue(MAX_QUEUE),
@@ -253,7 +253,7 @@ void CMIDI::Event(unsigned char Status, unsigned char Data1, unsigned char Data2
 	default:
 		switch (MsgType) {
 			case MIDI_MSG_NOTE_OFF:
-			case MIDI_MSG_NOTE_ON: 
+			case MIDI_MSG_NOTE_ON:
 			case MIDI_MSG_PITCH_WHEEL:
 				Enqueue(MsgType, MsgChannel, Data1, Data2);
 				pView->PostMessage(WM_USER_MIDI_EVENT);
@@ -265,16 +265,17 @@ void CMIDI::Event(unsigned char Status, unsigned char Data1, unsigned char Data2
 bool CMIDI::ReadMessage(unsigned char & Message, unsigned char & Channel, unsigned char & Data1, unsigned char & Data2)
 {
 	bool Result = false;
-	
-	if (auto MidiMessage = m_MidiQueue.front()) {
-		m_MidiQueue.pop();
+
+	if (auto pMidiMessage = m_MidiQueue.front()) {
 		Result = true;
 
-		Message = MidiMessage->MsgType;
-		Channel = MidiMessage->MsgChan;
-		Data1	= MidiMessage->Data1;
-		Data2	= MidiMessage->Data2;
-		m_iQuant = MidiMessage->Quantization;
+		Message = pMidiMessage->MsgType;
+		Channel = pMidiMessage->MsgChan;
+		Data1	= pMidiMessage->Data1;
+		Data2	= pMidiMessage->Data2;
+		m_iQuant = pMidiMessage->Quantization;
+
+		m_MidiQueue.pop();
 	}
 
 	return Result;
@@ -359,12 +360,12 @@ bool CMIDI::IsAvailable() const
 	return m_hMIDIIn != NULL;
 }
 
-int CMIDI::GetInputDevice() const 
-{ 
-	return m_iInDevice; 
+int CMIDI::GetInputDevice() const
+{
+	return m_iInDevice;
 }
 
-int CMIDI::GetOutputDevice() const 
-{ 
-	return m_iOutDevice; 
+int CMIDI::GetOutputDevice() const
+{
+	return m_iOutDevice;
 }

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -696,11 +696,12 @@ void CSoundGen::ThreadEntry()
 	}
 	while (true) {
 		while (auto pMessage = m_MessageQueue.front()) {
+			GuiMessage message = *pMessage;
 			m_MessageQueue.pop();
-			if (pMessage->message == WM_QUIT) {
+			if (message.message == WM_QUIT) {
 				goto end_while;
 			}
-			if (!DispatchGuiMessage(*pMessage)) {
+			if (!DispatchGuiMessage(message)) {
 				goto end_while;
 			}
 		}


### PR DESCRIPTION
The reader loses access to the front pointer as soon as it pops from the queue, since from that point onward, the writer can overwrite it with a new message. Instead the reader must finish using the pointer or copy the value out, before popping from the queue.

This bug terrifies me, that I managed to write it, not catch it reviewing my own code despite years of atomic threading experience, and only realized I made a mistake weeks later, when reading an paper (https://lmax-exchange.github.io/disruptor/files/Disruptor-1.0.pdf).