### PR TITLE
Stop rejecting valid files using features missing from vanilla FT

### DIFF
--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -1686,7 +1686,6 @@ void CFamiTrackerDoc::ReadBlock_Parameters(CDocumentFile *pDocFile, const int Ve
 		m_iExpansionChip = pDocFile->GetBlockChar();
 
 	m_iChannelsAvailable = AssertRange(pDocFile->GetBlockInt(), 1, MAX_CHANNELS, "Channel count");		// // //
-	AssertRange<MODULE_ERROR_OFFICIAL>(static_cast<int>(m_iChannelsAvailable), 1, MAX_CHANNELS - 1, "Channel count");
 
 	m_iMachine = static_cast<machine_t>(pDocFile->GetBlockInt());
 	AssertFileData(m_iMachine == NTSC || m_iMachine == PAL, "Unknown machine");
@@ -1890,7 +1889,6 @@ void CFamiTrackerDoc::ReadBlock_Instruments(CDocumentFile *pDocFile, const int V
 void CFamiTrackerDoc::ReadBlock_Sequences(CDocumentFile *pDocFile, const int Version)
 {
 	unsigned int Count = AssertRange(pDocFile->GetBlockInt(), 0, MAX_SEQUENCES * SEQ_COUNT, "2A03 sequence count");
-	AssertRange<MODULE_ERROR_OFFICIAL>(Count, 0U, static_cast<unsigned>(MAX_SEQUENCES * SEQ_COUNT - 1), "2A03 sequence count");		// // //
 
 	if (Version == 1) {
 		for (unsigned int i = 0; i < Count; ++i) {
@@ -1999,7 +1997,6 @@ void CFamiTrackerDoc::ReadBlock_Sequences(CDocumentFile *pDocFile, const int Ver
 void CFamiTrackerDoc::ReadBlock_SequencesVRC6(CDocumentFile *pDocFile, const int Version)
 {
 	unsigned int Count = AssertRange(pDocFile->GetBlockInt(), 0, MAX_SEQUENCES * SEQ_COUNT, "VRC6 sequence count");
-	AssertRange<MODULE_ERROR_OFFICIAL>(Count, 0U, static_cast<unsigned>(MAX_SEQUENCES), "VRC6 sequence count");		// // //
 
 	CSequenceManager *pManager = GetSequenceManager(INST_VRC6);		// // //
 
@@ -2073,7 +2070,6 @@ void CFamiTrackerDoc::ReadBlock_SequencesVRC6(CDocumentFile *pDocFile, const int
 void CFamiTrackerDoc::ReadBlock_SequencesN163(CDocumentFile *pDocFile, const int Version)
 {
 	unsigned int Count = AssertRange(pDocFile->GetBlockInt(), 0, MAX_SEQUENCES * SEQ_COUNT, "N163 sequence count");
-	AssertRange<MODULE_ERROR_OFFICIAL>(Count, 0U, static_cast<unsigned>(MAX_SEQUENCES * SEQ_COUNT - 1), "N163 sequence count");		// // //
 
 	CSequenceManager *pManager = GetSequenceManager(INST_N163);		// // //
 
@@ -2109,7 +2105,6 @@ void CFamiTrackerDoc::ReadBlock_SequencesN163(CDocumentFile *pDocFile, const int
 void CFamiTrackerDoc::ReadBlock_SequencesS5B(CDocumentFile *pDocFile, const int Version)
 {
 	unsigned int Count = AssertRange(pDocFile->GetBlockInt(), 0, MAX_SEQUENCES * SEQ_COUNT, "5B sequence count");
-	AssertRange<MODULE_ERROR_OFFICIAL>(Count, 0U, static_cast<unsigned>(MAX_SEQUENCES * SEQ_COUNT - 1), "N163 sequence count");		// // //
 
 	CSequenceManager *pManager = GetSequenceManager(INST_S5B);		// // //
 

--- a/Source/FamiTrackerTypes.h
+++ b/Source/FamiTrackerTypes.h
@@ -87,7 +87,7 @@ const int ECHO_BUFFER_LENGTH = 3;
 
 // Number of available channels (max) TODO: should not be used anymore!
 // instead, check the channelsavailable variable and allocate dynamically
-const int MAX_CHANNELS	 = 5 + 3 + 2 + 6 + 1 + 8 + 3;
+const int MAX_CHANNELS	 = 5 + 3 + 2 + 8 + 1 + 6 + 3;
 
 const int CHANNELS_DEFAULT = 5;
 const int CHANNELS_VRC6	   = 3;

--- a/Source/InstrumentN163.cpp
+++ b/Source/InstrumentN163.cpp
@@ -98,12 +98,10 @@ bool CInstrumentN163::Load(CDocumentFile *pDocFile)
 
 	m_iWaveSize = CModuleException::AssertRangeFmt(pDocFile->GetBlockInt(), 4, MAX_WAVE_SIZE, "N163 wave size", "%i");
 	m_iWavePos = CModuleException::AssertRangeFmt(pDocFile->GetBlockInt(), 0, MAX_WAVE_SIZE - 1, "N163 wave position", "%i");
-	CModuleException::AssertRangeFmt<MODULE_ERROR_OFFICIAL>(m_iWavePos, 0, 0x7F, "N163 wave position", "%i");
 	if (pDocFile->GetBlockVersion() >= 8) {		// // // 050B
 		bool AutoPosition = pDocFile->GetBlockInt() != 0;
 	}
 	m_iWaveCount = CModuleException::AssertRangeFmt(pDocFile->GetBlockInt(), 1, MAX_WAVE_COUNT, "N163 wave count", "%i");
-	CModuleException::AssertRangeFmt<MODULE_ERROR_OFFICIAL>(m_iWaveCount, 1, 0x10, "N163 wave count", "%i");
 	
 	for (int i = 0; i < m_iWaveCount; ++i) {
 		for (int j = 0; j < m_iWaveSize; ++j) try {

--- a/Source/Settings.h
+++ b/Source/Settings.h
@@ -37,8 +37,8 @@ enum EDIT_STYLES {		// // // renamed
 enum module_error_level_t {		// // //
 	MODULE_ERROR_NONE,		/*!< No error checking at all (warning) */
 	MODULE_ERROR_DEFAULT,	/*!< Usual error checking */
-	MODULE_ERROR_OFFICIAL,	/*!< Special bounds checking according to the official build */
 	MODULE_ERROR_STRICT,	/*!< Extra validation for some values */
+	MODULE_ERROR_MAX = MODULE_ERROR_STRICT,
 };
 
 enum WIN_STATES {


### PR DESCRIPTION
Previously, in modules with many instrument sequences for a given chip, or if any N163 instrument contained more than 16 waves or was placed ≥ 128, Dn-FT would allow creating and saving these modules, but would reject them upon reopening. This is highly undesirable behavior, and resulted in some people being unable to open modules from the 2022 demo compo.

Since vanilla FT is dead, remove the vanilla checks altogether. This removes the "official" validation level, as well as all checks that turned on at that level, since they could all reject valid documents being saved and reopened (examples at [vanilla-compat.zip](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/files/9076077/vanilla-compat.zip)).

For users who already set their validation levels to "official" or "strict", this maps to the new "strict" validation level.