### PR TITLE
Properly terminate stuck audio thread when closing the program

### DIFF
--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -483,6 +483,11 @@ void CFamiTrackerApp::ShutDownSynth()
 	// Send quit message. Note that this object may be deleted now!
 	m_pSoundGenerator->PostGuiMessage(AM_QUIT, 0, 0);
 
+	// If audio thread is waiting on stuck WASAPI, interrupt the wait. On the next loop
+	// iteration, it will see the quit message.
+	// TODO fix data race on closing m_hInterruptEvent or deleting m_pSoundGenerator
+	m_pSoundGenerator->Interrupt();
+
 	// Wait for thread to exit
 	DWORD dwResult = ::WaitForSingleObject(
 		stdThread.native_handle(), CSoundGen::AUDIO_TIMEOUT + 1000

--- a/Source/FamiTracker.h
+++ b/Source/FamiTracker.h
@@ -41,7 +41,7 @@
 
 // Inter-process commands
 enum {
-	IPC_LOAD = 1,	
+	IPC_LOAD = 1,
 	IPC_LOAD_PLAY
 };
 
@@ -139,7 +139,7 @@ public:
 	CMIDI			*GetMIDI() const			{ ASSERT(m_pMIDI); return m_pMIDI; }
 	CSettings		*GetSettings() const		{ ASSERT(m_pSettings); return m_pSettings; }
 	CChannelMap		*GetChannelMap() const		{ ASSERT(m_pChannelMap); return m_pChannelMap; }
-	
+
 	CCustomExporters *GetCustomExporters() const;
 
 	//
@@ -187,7 +187,7 @@ public:
 	// Overrides
 public:
 	virtual BOOL InitInstance();
-	virtual int ExitInstance();	
+	virtual int ExitInstance();
 
 	// Implementation
 	DECLARE_MESSAGE_MAP()

--- a/Source/FamiTracker.h
+++ b/Source/FamiTracker.h
@@ -27,8 +27,9 @@
 
 // FamiTracker.h : main header file for the FamiTracker application
 
-#include <thread>		// // //
+#include <memory>
 #include <string>
+#include <thread>		// // //
 
 // Support DLL translations
 #define SUPPORT_TRANSLATIONS
@@ -117,7 +118,6 @@ public:
 	void			ReloadColorScheme();
 	int				GetCPUUsage() const;
 	bool			IsThemeActive() const;
-	void			RemoveSoundGenerator();
 	void			RefreshFrameEditor();
 	void			ThreadDisplayMessage(LPCTSTR lpszText, UINT nType = 0, UINT nIDHelp = 0);
 	void			ThreadDisplayMessage(UINT nIDPrompt, UINT nType = 0, UINT nIDHelp = 0);
@@ -135,7 +135,7 @@ public:
 	// Get-functions
 	CMainFrame		*GetMainFrame() const;		// // //
 	CAccelerator	*GetAccelerator() const		{ ASSERT(m_pAccel); return m_pAccel; }
-	CSoundGen		*GetSoundGenerator() const	{ ASSERT(m_pSoundGenerator); return m_pSoundGenerator; }
+	CSoundGen		*GetSoundGenerator() const	{ ASSERT(m_pSoundGenerator); return m_pSoundGenerator.get(); }
 	CMIDI			*GetMIDI() const			{ ASSERT(m_pMIDI); return m_pMIDI; }
 	CSettings		*GetSettings() const		{ ASSERT(m_pSettings); return m_pSettings; }
 	CChannelMap		*GetChannelMap() const		{ ASSERT(m_pChannelMap); return m_pChannelMap; }
@@ -160,7 +160,7 @@ private:
 	// Objects
 	CMIDI			*m_pMIDI;
 	CAccelerator	*m_pAccel;					// Keyboard accelerator
-	CSoundGen		*m_pSoundGenerator;			// Sound synth & player
+	std::shared_ptr<CSoundGen> m_pSoundGenerator;			// Sound synth & player
 	CSettings		*m_pSettings;				// Program settings
 	CChannelMap		*m_pChannelMap;
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -120,46 +120,46 @@ int dither(long size);
 static constexpr size_t MESSAGE_QUEUE_SIZE = 8192;
 
 CSoundGen::CSoundGen() :
+	m_pInstRecorder(new CInstrumentRecorder(this)),
 	m_MessageQueue(MESSAGE_QUEUE_SIZE),
-	m_pAPU(NULL),
-	m_pSoundInterface(NULL),
-	m_pSoundStream(NULL),
 	m_pDocument(NULL),
 	m_pTrackerView(NULL),
-	m_bRequestRenderStart(false),
-	m_bRendering(false),
-	m_bPlaying(false),
-	m_bHaltRequest(false),
-	m_bDoHalt(false),		// // //
-	m_pPreviewSample(NULL),
+	m_pSoundInterface(NULL),
+	m_pSoundStream(NULL),
 	m_pVisualizerWnd(NULL),
-	m_iSpeed(0),
-	m_iTempo(0),
-	m_iGrooveIndex(-1),		// // //
-	m_iGroovePosition(0),		// // //
-	m_pInstRecorder(new CInstrumentRecorder(this)),		// // //
-	m_bWaveChanged(0),
-	m_iMachineType(NTSC),
-	m_CoInitialized(false),
+	m_pAPU(NULL),
+	currN163LevelOffset(0),
+	m_pPreviewSample(NULL),
+	m_CoInitialized(false),		// // //
 	m_bRunning(false),
 	m_hInterruptEvent(NULL),
 	m_bBufferTimeout(false),
-	m_bDirty(false),
+	m_bBufferUnderrun(false),
+	m_bAudioClipping(false),		// // //
+	m_iClipCounter(0),		// // //
+	m_iTempo(0),		// // //
+	m_iSpeed(0),
+	m_iGrooveIndex(-1),
+	m_iGroovePosition(0),
+	m_iPlayTicks(0),
+	m_bPlaying(false),
+	m_bHaltRequest(false),
+	m_iConsumedCycles(0),
+	m_bDoHalt(false),
+	m_iMachineType(NTSC),
+	m_bRequestRenderStart(false),
+	m_bRendering(false),
+	m_iBPMCachePosition(0),
+	m_iRegisterStream(),
+	m_bWaveChanged(0),		// // //
 	m_iQueuedFrame(-1),
+	m_iPlayTrack(0),
 	m_iPlayFrame(0),
 	m_iPlayRow(0),
-	m_iPlayTrack(0),
-	m_iPlayTicks(0),
-	m_iConsumedCycles(0),
-	m_iRegisterStream(),		// // //
-	m_bBufferUnderrun(false),
-	m_bAudioClipping(false),
-	m_iClipCounter(0),
+	m_bDirty(false),
 	m_pSequencePlayPos(NULL),
-	m_iSequencePlayPos(0),
-	m_iSequenceTimeout(0),
-	m_iBPMCachePosition(0),		// // //
-	currN163LevelOffset(0)
+	m_iSequencePlayPos(0),		// // //
+	m_iSequenceTimeout(0)
 {
 	TRACE("SoundGen: Object created\n");
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -658,8 +658,10 @@ bool CSoundGen::IsRunning() const
 
 //// Sound buffer handling /////////////////////////////////////////////////////////////////////////////////
 
-bool CSoundGen::BeginThread()
+bool CSoundGen::BeginThread(std::shared_ptr<CSoundGen> self_shared)
 {
+	ASSERT(this == self_shared.get());
+
 	// Initialize sound, this is only called once!
 	// Start with NTSC by default
 
@@ -684,8 +686,8 @@ bool CSoundGen::BeginThread()
 	m_pSoundInterface->EnumerateDevices();
 
 	// Start thread when audio is done
-	m_audioThread = std::thread([this]() {
-		ThreadEntry();
+	m_audioThread = std::thread([self_shared = std::move(self_shared)]() {
+		self_shared->ThreadEntry();
 	});
 
 	return true;
@@ -717,8 +719,6 @@ void CSoundGen::ThreadEntry()
 	end_while:
 
 	ExitInstance();
-	// lolmfc
-	delete this;
 }
 
 
@@ -2159,8 +2159,6 @@ void CSoundGen::ExitInstance()
 
 	// Make sure sound interface is shut down
 	CloseAudio();
-
-	theApp.RemoveSoundGenerator();
 
 	m_bRunning = false;
 

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -2175,8 +2175,10 @@ void CSoundGen::OnIdle()
 	// Main loop for audio playback thread
 	//
 
-	if (!m_pDocument || !m_pSoundStream || !m_pDocument->IsFileLoaded())
+	if (!m_pDocument || !m_pSoundStream || !m_pDocument->IsFileLoaded()) {
+		Sleep(100);
 		return;
+	}
 
 	++m_iFrameCounter;
 

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -31,6 +31,7 @@
 #include "gsl/span"
 #include "rigtorp/SPSCQueue.h"
 #include "libsamplerate/include/samplerate.h"
+#include "utils/handle_ptr.h"
 #include <queue>		// // //
 #include "Common.h"
 
@@ -357,7 +358,14 @@ private:
 	mutable std::mutex m_csVisualizerWndLock;
 
 	// Handles
-	HANDLE				m_hInterruptEvent;					// Used to interrupt sound buffer syncing
+
+	/// Used to interrupt sound buffer syncing. Never null. To avoid data races, we never
+	/// overwrite this handle. Instead we assign once (in the constructor), then
+	/// SetEvent/ResetEvent afterwards.
+	///
+	/// It doesn't really matter, considering CSoundGen::BeginThread() is only ever
+	/// called once, but it's cleaner this way.
+	HandlePtr m_hInterruptEvent;
 
 // Sound variables (TODO: move sound to a new class?)
 private:

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -132,7 +132,7 @@ public:
 	void		LoadMachineSettings();		// // // 050B
 
 	// Thread management functions
-	bool		BeginThread();
+	bool BeginThread(std::shared_ptr<CSoundGen> self);
 
 private:
 	void ThreadEntry();

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -34,6 +34,7 @@
 #include "utils/handle_ptr.h"
 #include <queue>		// // //
 #include "Common.h"
+#include "FamiTrackerTypes.h"
 
 #include <atomic>
 #include <cstdint>


### PR DESCRIPTION
I observed the audio thread to get stuck waiting for room to write audio, on a Windows 7 machine with an stuck audio daemon (audiodg.exe). It happens intermittently due to either bad apps, a broken audiodg.exe or APO plugin, or bad sound drivers (not sure which).

To make it work, I had to switch CSoundGen to shared_ptr ownership, which is an improvement to code maintainability in general (avoids the possibility of dangling pointers). This is a prerequisite for future refactorings.

I also fixed the audio thread burning CPU when audio isn't running (due to no audio devices, an audio initialization error, etc.).

This *should* be correct? I'm not confident lol