### PR TITLE
Update build tools, VS solution, CMake lists, and corresponding documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,28 @@ endif()
 
 
 # linking
-TARGET_LINK_LIBRARIES(${exe}
-        Dbghelp winmm comctl32 Avrt Version htmlhelp
-        samplerate)
+# Specify static MFC libraries nafxcw and Libcmt to avoid linker order issues
+if (STATIC_MSVCRT)
+	if (CMAKE_BUILD_TYPE MATCHES DEBUG)
+		TARGET_LINK_LIBRARIES(${exe}
+				Dbghelp winmm comctl32 Avrt Version htmlhelp
+				samplerate nafxcwd Libcmtd)
+	else ()
+		TARGET_LINK_LIBRARIES(${exe}
+				Dbghelp winmm comctl32 Avrt Version htmlhelp
+				samplerate nafxcw Libcmt)
+	endif ()
+else ()
+	if (CMAKE_BUILD_TYPE MATCHES DEBUG)
+		TARGET_LINK_LIBRARIES(${exe}
+				Dbghelp winmm comctl32 Avrt Version htmlhelp
+				samplerate MSVCRTD)
+	else ()
+		TARGET_LINK_LIBRARIES(${exe}
+				Dbghelp winmm comctl32 Avrt Version htmlhelp
+				samplerate MSVCRT)
+	endif ()
+endif ()
 
 # Dn-FamiTracker.rc includes res/Dn-FamiTracker.manifest.
 # To prevent manifest linking errors:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,12 @@ add_subdirectory_optimized("Source/libsamplerate" EXCLUDE_FROM_ALL)
 include(cmake/exe.cmake)
 
 #builds the .chm file
-if(WIN32)
-    add_custom_command(TARGET ${exe}
-        PRE_BUILD
-        COMMAND cmd /c ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compile-chm.bat
-        COMMAND move Dn-Famitracker.chm ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Generating help file...")
-endif()
+add_custom_command(TARGET ${exe}
+	PRE_BUILD
+	COMMAND cmd /c ${CMAKE_CURRENT_SOURCE_DIR}/cmake/compile-chm.bat
+	COMMAND move Dn-Famitracker.chm ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>
+	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+	COMMENT "Generating help file...")
 
 target_compile_features(${exe} PRIVATE cxx_std_17)
 

--- a/Dn-FT_VS_Dependencies.vsconfig
+++ b/Dn-FT_VS_Dependencies.vsconfig
@@ -5,6 +5,7 @@
     "Microsoft.VisualStudio.Workload.CoreEditor",
     "Microsoft.VisualStudio.Component.Roslyn.Compiler",
     "Microsoft.Component.MSBuild",
+    "Microsoft.VisualStudio.Component.Roslyn.LanguageServices",
     "Microsoft.VisualStudio.Component.TextTemplating",
     "Microsoft.VisualStudio.Component.IntelliCode",
     "Microsoft.VisualStudio.Component.VC.CoreIde",
@@ -17,8 +18,13 @@
     "Microsoft.VisualStudio.Component.VC.CMake.Project",
     "Microsoft.VisualStudio.Component.VC.ATL",
     "Microsoft.VisualStudio.Component.VC.ATLMFC",
+    "Microsoft.VisualStudio.Component.VC.ATL.Spectre",
+    "Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre",
+    "Microsoft.VisualStudio.Component.VC.ASAN",
+    "Microsoft.VisualStudio.Component.Windows10SDK.20348",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
     "Microsoft.Component.VC.Runtime.UCRTSDK",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
-    "Microsoft.VisualStudio.Component.WinXP"
+    "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre"
   ]
 }

--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -209,7 +209,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;nafxcw.lib;Libcmt.lib</AdditionalDependencies>
+      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;nafxcw.lib;Libcmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>
       </Version>
       <AdditionalLibraryDirectories>$(LibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
@@ -253,7 +253,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;nafxcw.lib;Libcmt.lib</AdditionalDependencies>
+      <AdditionalDependencies>Dbghelp.lib;winmm.lib;comctl32.lib;Avrt.lib;Version.lib;htmlhelp.lib;nafxcw.lib;Libcmt.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <Version>
       </Version>
       <AdditionalLibraryDirectories>$(LibraryPath);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -31,27 +31,27 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <UseOfAtl>false</UseOfAtl>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <UseOfAtl>false</UseOfAtl>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseOfMfc>Static</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -437,7 +437,7 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="resource.h">
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo // Generated Help Map file.  Used by Dn-FamiTracker.HHP. &gt; "hlp\HTMLDefines.h"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">echo // Generated Help Map file.  Used by $(SolutionName).hhp. &gt; "hlp\HTMLDefines.h"
 echo. &gt; "hlp\HTMLDefines.h"
 echo // Commands (ID_* and IDM_*) &gt;&gt; "hlp\HTMLDefines.h"
 makehm /h ID_,HID_,0x10000 IDM_,HIDM_,0x10000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"
@@ -453,7 +453,7 @@ makehm /h IDD_,HIDD_,0x20000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"
 echo. &gt;&gt; "hlp\HTMLDefines.h"
 echo // Frame Controls (IDW_*) &gt;&gt; "hlp\HTMLDefines.h"
 makehm /h /a afxhh.h IDW_,HIDW_,0x50000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">echo // Generated Help Map file.  Used by Dn-FamiTracker.HHP. &gt; "hlp\HTMLDefines.h"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">echo // Generated Help Map file.  Used by $(SolutionName).hhp. &gt; "hlp\HTMLDefines.h"
 echo. &gt; "hlp\HTMLDefines.h"
 echo // Commands (ID_* and IDM_*) &gt;&gt; "hlp\HTMLDefines.h"
 makehm /h ID_,HID_,0x10000 IDM_,HIDM_,0x10000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"
@@ -473,7 +473,7 @@ makehm /h /a afxhh.h IDW_,HIDW_,0x50000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Generating map file for help compiler.</Message>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">hlp\HTMLDefines.h;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">hlp\HTMLDefines.h;%(Outputs)</Outputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">echo // Generated Help Map file.  Used by Dn-FamiTracker.HHP. &gt; "hlp\HTMLDefines.h"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">echo // Generated Help Map file.  Used by $(SolutionName).hhp. &gt; "hlp\HTMLDefines.h"
 echo. &gt; "hlp\HTMLDefines.h"
 echo // Commands (ID_* and IDM_*) &gt;&gt; "hlp\HTMLDefines.h"
 makehm /h ID_,HID_,0x10000 IDM_,HIDM_,0x10000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"
@@ -489,7 +489,7 @@ makehm /h IDD_,HIDD_,0x20000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"
 echo. &gt;&gt; "hlp\HTMLDefines.h"
 echo // Frame Controls (IDW_*) &gt;&gt; "hlp\HTMLDefines.h"
 makehm /h /a afxhh.h IDW_,HIDW_,0x50000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">echo // Generated Help Map file.  Used by Dn-FamiTracker.HHP. &gt; "hlp\HTMLDefines.h"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">echo // Generated Help Map file.  Used by $(SolutionName).hhp. &gt; "hlp\HTMLDefines.h"
 echo. &gt; "hlp\HTMLDefines.h"
 echo // Commands (ID_* and IDM_*) &gt;&gt; "hlp\HTMLDefines.h"
 makehm /h ID_,HID_,0x10000 IDM_,HIDM_,0x10000 "%(FullPath)" &gt;&gt; "hlp\HTMLDefines.h"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Dn-Famitracker is a fork of 0CC-FamiTracker that incorporates numerous fixes and
 
 ## Contributing
 
-[Contributing and compiling](CONTRIBUTING.md)
+[Contributing and compiling](docs/CONTRIBUTING.md)
 
 ## Downloads
 

--- a/Source/APU/FDS.cpp
+++ b/Source/APU/FDS.cpp
@@ -21,16 +21,13 @@
 ** Any permitted reproduction of these routines, in whole or in part,
 ** must bear this legend.
 */
-#define _USE_MATH_DEFINES
 
 #include "../stdafx.h"
 #include "APU.h"
 #include "FDS.h"
-#include "../RegisterState.h"		// // //s
-
-#include <cstdint>
-
-#include <cmath>
+#include "../RegisterState.h"		// // //
+#define _USE_MATH_DEFINES
+#include <math.h>		// !! !! M_PI
 
 // FDS interface, actual FDS emulation is in FDSSound.cpp
 

--- a/Source/APU/N163.cpp
+++ b/Source/APU/N163.cpp
@@ -21,7 +21,6 @@
 ** Any permitted reproduction of these routines, in whole or in part,
 ** must bear this legend.
 */
-#define _USE_MATH_DEFINES
 
 #include "../stdafx.h"
 #include "../FamiTracker.h"
@@ -30,9 +29,8 @@
 #include "APU.h"
 #include "N163.h"
 #include "../RegisterState.h"		// // //
-
-#include <cstdint>
-#include <cmath>
+#define _USE_MATH_DEFINES
+#include <math.h>		// !! !! M_PI
 
 //
 // Namco 163

--- a/Source/libsamplerate/libsamplerate.vcxproj
+++ b/Source/libsamplerate/libsamplerate.vcxproj
@@ -29,14 +29,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
@@ -44,14 +44,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <PreferredToolArchitecture>x64</PreferredToolArchitecture>

--- a/cmake/compile-chm.bat
+++ b/cmake/compile-chm.bat
@@ -1,6 +1,6 @@
 rem call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
 @echo off
-echo // Generated Help Map file.  Used by Dn-FamiTracker.HHP. > "hlp\HTMLDefines.h"
+echo // Generated Help Map file.  Used by Dn-FamiTracker.hhp. > "hlp\HTMLDefines.h"
 echo. > "hlp\HTMLDefines.h"
 echo // Commands (ID_* and IDM_*) >> "hlp\HTMLDefines.h"
 makehm /h ID_,HID_,0x10000 IDM_,HIDM_,0x10000 "resource.h" >> "hlp\HTMLDefines.h"

--- a/cmake/exe.cmake
+++ b/cmake/exe.cmake
@@ -36,9 +36,22 @@ add_executable(${exe}
         version.h
 
         # Emulator cores
+        Source/APU/digital-sound-antiques/2413tone.h
+        Source/APU/digital-sound-antiques/281btone.h
+        Source/APU/digital-sound-antiques/emu2413.c
+        Source/APU/digital-sound-antiques/emu2413.h
+        Source/APU/digital-sound-antiques/vrc7tone_ft35.h
+        Source/APU/digital-sound-antiques/vrc7tone_ft36.h
+        Source/APU/digital-sound-antiques/vrc7tone_kt1.h
+        Source/APU/digital-sound-antiques/vrc7tone_kt2.h
+        Source/APU/digital-sound-antiques/vrc7tone_mo.h
+        Source/APU/digital-sound-antiques/vrc7tone_nuke.h
+        Source/APU/digital-sound-antiques/vrc7tone_rw.h
+
         Source/APU/mesen/BaseFdsChannel.h
         Source/APU/mesen/FdsAudio.h
         Source/APU/mesen/ModChannel.h
+        Source/APU/mesen/Namco163Audio.h
 
         Source/APU/nsfplay/xgm/debugout.h
         Source/APU/nsfplay/xgm/xtypes.h
@@ -46,17 +59,6 @@ add_executable(${exe}
         Source/APU/nsfplay/xgm/devices/devinfo.h
         Source/APU/nsfplay/xgm/devices/CPU/nes_cpu.h
         Source/APU/nsfplay/xgm/devices/Sound/nsfplay_math.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/emu2413.c
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/emu2413.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/2413tone.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/281btone.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_ft35.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_ft36.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_kt1.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_kt2.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_mo.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_nuke.h
-        Source/APU/nsfplay/xgm/devices/Sound/legacy/vrc7tone_rw.h
         Source/APU/nsfplay/xgm/devices/Sound/nes_apu.cpp
         Source/APU/nsfplay/xgm/devices/Sound/nes_apu.h
         Source/APU/nsfplay/xgm/devices/Sound/nes_dmc.cpp
@@ -65,8 +67,10 @@ add_executable(${exe}
         # Libraries
         Source/Blip_Buffer/Blip_Buffer.cpp
         Source/Blip_Buffer/Blip_Buffer.h
+
         Source/FFT/FftBuffer.h
         Source/FFT/FftComplex.hpp
+
         Source/gsl/gsl
         Source/gsl/gsl_algorithm
         Source/gsl/gsl_assert
@@ -77,15 +81,20 @@ add_executable(${exe}
         Source/gsl/span
         Source/gsl/span_ext
         Source/gsl/string_span
+
         Source/json/json.hpp
+
         Source/resampler/resample.cpp
         Source/resampler/resample.hpp
         Source/resampler/resample.inl
         Source/resampler/sinc.cpp
         Source/resampler/sinc.hpp
+
         Source/rigtorp/SPSCQueue.h
+
         Source/str_conv/str_conv.hpp
         Source/str_conv/utf8_conv.hpp
+
         Source/type_safe/arithmetic_policy.hpp
         Source/type_safe/boolean.hpp
         Source/type_safe/bounded_type.hpp
@@ -119,8 +128,26 @@ add_executable(${exe}
         Source/type_safe/types.hpp
         Source/type_safe/variant.hpp
         Source/type_safe/visitor.hpp
+
         Source/WinSDK/VersionHelpers.h
         Source/WinSDK/winapifamily.h
+
+        # NSF driver binaries
+        Source/drivers/drv_2a03.h
+        Source/drivers/drv_all.h
+        Source/drivers/drv_fds.h
+        Source/drivers/drv_mmc5.h
+        Source/drivers/drv_n163.h
+        Source/drivers/drv_s5b.h
+        Source/drivers/drv_vrc6.h
+        Source/drivers/drv_vrc7.h
+
+        # Utilities
+        Source/utils/ftmath.cpp
+        Source/utils/ftmath.h
+        Source/utils/handle_ptr.h
+        Source/utils/input.h
+        Source/utils/variadic_minmax.h
 
         # Sources
         Source/APU/2A03.cpp
@@ -151,19 +178,7 @@ add_executable(${exe}
         Source/APU/VRC6.h
         Source/APU/VRC7.cpp
         Source/APU/VRC7.h
-        Source/drivers/drv_2a03.h
-        Source/drivers/drv_all.h
-        Source/drivers/drv_fds.h
-        Source/drivers/drv_mmc5.h
-        Source/drivers/drv_n163.h
-        Source/drivers/drv_s5b.h
-        Source/drivers/drv_vrc6.h
-        Source/drivers/drv_vrc7.h
-        Source/utils/ftmath.cpp
-        Source/utils/ftmath.h
-        Source/utils/handle_ptr.h
-        Source/utils/input.h
-        Source/utils/variadic_minmax.h
+		
         Source/AboutDlg.cpp
         Source/AboutDlg.h
         Source/Accelerator.cpp
@@ -249,11 +264,11 @@ add_executable(${exe}
         Source/CustomControls.h
         Source/CustomExporter.cpp
         Source/CustomExporter.h
-        Source/CustomExporter_C_Interface.cpp
-        Source/CustomExporter_C_Interface.h
         Source/CustomExporterInterfaces.h
         Source/CustomExporters.cpp
         Source/CustomExporters.h
+        Source/CustomExporter_C_Interface.cpp
+        Source/CustomExporter_C_Interface.h
         Source/DetuneDlg.cpp
         Source/DetuneDlg.h
         Source/DetuneTable.cpp

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,26 +15,25 @@ FamiTracker (and most of its forks) is an MFC application with project files mad
 
 
 ## Dependencies and Building
-To edit and/or build the source, you may use Visual Studio 2019, or alternatively, any IDE that supports CMake. You will need the following dependencies:
+To edit and/or build the source, you may use Visual Studio 2022, or alternatively, any IDE that supports CMake. You will need the following dependencies:
 
-- [HTMLHelp](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/htmlhelp/microsoft-html-help-downloads) to build the manual
+- [HTML Help Workshop](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/htmlhelp/microsoft-html-help-downloads) to build the manual. Note that HTML Help Workshop is no longer supported and thus no longer available to download on Microsoft's website. [Link to archived download.](https://web.archive.org/web/20200720082840/http://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe)
 - For any IDE that supports building via CMake:
   - CMake
   - The latest MSVC build tools (may be from VS Installer or from other sources)
   - These dependencies can be installed through the Visual Studio Installer:
-     - C++ MFC for latest v142 build tools (x86 & x64)
-     - C++ ATL for latest v142 build tools (x86 & x64)
+     - C++ MFC for latest v143 build tools (x86 & x64)
+     - C++ ATL for latest v143 build tools (x86 & x64)
 
-- For Visual Studio 2019:
-   - C++ Windows XP Support for VS 2017
+- For Visual Studio 2022:
    - Windows Universal CRT SDK
-   - C++ MFC for latest v142 build tools (x86 & x64)
-   - C++ ATL for latest v142 build tools (x86 & x64)
+   - C++ MFC for latest v143 build tools (x86 & x64)
+   - C++ ATL for latest v143 build tools (x86 & x64)
    - The Desktop development with C++ workload, which includes:
       - MSVC v142 - VS 2019 C++ x64/x86 build tools (latest version)
       - C++ CMake tools for Windows
 
-  - Alternatively, you can install the components mentioned via the [provided .vsconfig file](Dn-FT_VS_Dependencies.vsconfig).
+  - Alternatively, you can install the components mentioned via the [provided .vsconfig file](../Dn-FT_VS_Dependencies.vsconfig).
 
 
 

--- a/docs/enable_asan.md
+++ b/docs/enable_asan.md
@@ -6,8 +6,6 @@
 
 Project -> Dn-FamiTracker Properties
 - Configuration Properties
-	- General
-		- Platform Toolset: Visual Studio 2022 (v143)
 	- Advanced
 		- Use of MFC: Use MFC in a Shared DLL
 	- C/C++

--- a/hlp/hlp.vcxproj
+++ b/hlp/hlp.vcxproj
@@ -23,33 +23,33 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{afd2f6e3-e658-4a1b-a691-8f10a858321b}</ProjectGuid>
     <RootNamespace>hlp</RootNamespace>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
+    <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v141_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -156,39 +156,39 @@
     </None>
     <CustomBuild Include="Dn-FamiTracker.hhp">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">start /wait hhc "Dn-FamiTracker.hhp"
-if not exist "Dn-FamiTracker.chm" goto :HelpError
-copy "Dn-FamiTracker.chm" "$(OutDir)Dn-FamiTracker.chm"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">start /wait hhc "$(SolutionName).hhp"
+if not exist "$(SolutionName).chm" goto :HelpError
+copy "$(SolutionName).chm" "$(OutDir)$(SolutionName).chm"
 goto :HelpDone
 :HelpError
-echo hlp\Dn-FamiTracker.hhp(1) : error:Problem encountered creating help file
+echo $(ProjectDir)$(SolutionName).hhp(1) : error:Problem encountered creating help file
 echo.
 :HelpDone
 echo.</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">start /wait hhc "Dn-FamiTracker.hhp"
-if not exist "Dn-FamiTracker.chm" goto :HelpError
-copy "Dn-FamiTracker.chm" "$(OutDir)Dn-FamiTracker.chm"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">start /wait hhc "$(SolutionName).hhp"
+if not exist "$(SolutionName).chm" goto :HelpError
+copy "$(SolutionName).chm" "$(OutDir)$(SolutionName).chm"
 goto :HelpDone
 :HelpError
-echo hlp\Dn-FamiTracker.hhp(1) : error:Problem encountered creating help file
+echo $(ProjectDir)$(SolutionName).hhp(1) : error:Problem encountered creating help file
 echo.
 :HelpDone
 echo.</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">start /wait hhc "Dn-FamiTracker.hhp"
-if not exist "Dn-FamiTracker.chm" goto :HelpError
-copy "Dn-FamiTracker.chm" "$(OutDir)Dn-FamiTracker.chm"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">start /wait hhc "$(SolutionName).hhp"
+if not exist "$(SolutionName).chm" goto :HelpError
+copy "$(SolutionName).chm" "$(OutDir)$(SolutionName).chm"
 goto :HelpDone
 :HelpError
-echo hlp\Dn-FamiTracker.hhp(1) : error:Problem encountered creating help file
+echo $(ProjectDir)$(SolutionName).hhp(1) : error:Problem encountered creating help file
 echo.
 :HelpDone
 echo.</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">start /wait hhc "Dn-FamiTracker.hhp"
-if not exist "Dn-FamiTracker.chm" goto :HelpError
-copy "Dn-FamiTracker.chm" "$(OutDir)Dn-FamiTracker.chm"
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">start /wait hhc "$(SolutionName).hhp"
+if not exist "$(SolutionName).chm" goto :HelpError
+copy "$(SolutionName).chm" "$(OutDir)$(SolutionName).chm"
 goto :HelpDone
 :HelpError
-echo hlp\Dn-FamiTracker.hhp(1) : error:Problem encountered creating help file
+echo $(ProjectDir)$(SolutionName).hhp(1) : error:Problem encountered creating help file
 echo.
 :HelpDone
 echo.</Command>
@@ -196,14 +196,14 @@ echo.</Command>
       <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Making help file...</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Making help file...</Message>
       <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Making help file...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)$(ProjectName).chm</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)$(ProjectName).chm</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)$(ProjectName).chm</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)$(ProjectName).chm</Outputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">..\HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">..\HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">..\HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">..\HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(OutDir)$(SolutionName).chm</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutDir)$(SolutionName).chm</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(OutDir)$(SolutionName).chm</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)$(SolutionName).chm</Outputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
+      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">HTMLDefines.h;%(AdditionalInputs)</AdditionalInputs>
     </CustomBuild>
     <None Include="2a03.htm">
       <DeploymentContent>true</DeploymentContent>
@@ -223,7 +223,13 @@ echo.</Command>
     <None Include="config_appearance.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <None Include="config_emulation.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="config_general.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="config_gui.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="config_midi.htm">
@@ -236,6 +242,9 @@ echo.</Command>
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="config_sound.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="config_version.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="control_panel.htm">
@@ -261,6 +270,9 @@ echo.</Command>
     <None Include="fds.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <None Include="instruments.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
     <None Include="interface.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
@@ -283,6 +295,12 @@ echo.</Command>
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="menu_module.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="menu_pattern.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="menu_song.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="menu_tracker.htm">
@@ -310,6 +328,9 @@ echo.</Command>
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="shortcuts.htm">
+      <DeploymentContent>true</DeploymentContent>
+    </None>
+    <None Include="sound.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
     <None Include="sound_overview.htm">

--- a/hlp/hlp.vcxproj.filters
+++ b/hlp/hlp.vcxproj.filters
@@ -141,6 +141,15 @@
     <None Include="config_sound.htm">
       <Filter>HTML Help Topics\Interface\Configuration</Filter>
     </None>
+    <None Include="config_version.htm">
+      <Filter>HTML Help Topics\Interface\Configuration</Filter>
+    </None>
+    <None Include="config_gui.htm">
+      <Filter>HTML Help Topics\Interface\Configuration</Filter>
+    </None>
+    <None Include="config_emulation.htm">
+      <Filter>HTML Help Topics\Interface\Configuration</Filter>
+    </None>
     <None Include="menu_edit.htm">
       <Filter>HTML Help Topics\Interface\Menus</Filter>
     </None>
@@ -160,6 +169,12 @@
       <Filter>HTML Help Topics\Interface\Menus</Filter>
     </None>
     <None Include="menu_view.htm">
+      <Filter>HTML Help Topics\Interface\Menus</Filter>
+    </None>
+    <None Include="menu_song.htm">
+      <Filter>HTML Help Topics\Interface\Menus</Filter>
+    </None>
+    <None Include="menu_pattern.htm">
       <Filter>HTML Help Topics\Interface\Menus</Filter>
     </None>
     <None Include="comments.htm">
@@ -184,6 +199,12 @@
       <Filter>HTML Help Topics\Interface\Dialogs</Filter>
     </None>
     <None Include="speed.htm">
+      <Filter>HTML Help Topics\Interface\Dialogs</Filter>
+    </None>
+    <None Include="instruments.htm">
+      <Filter>HTML Help Topics\Interface\Dialogs</Filter>
+    </None>
+    <None Include="sound.htm">
       <Filter>HTML Help Topics\Interface\Dialogs</Filter>
     </None>
   </ItemGroup>


### PR DESCRIPTION
This pull request aims to update the project solution and corresponding files to Visual Studio 2022 (v143). This also aims to update CMake build files to a working state.

### Changes in this PR:
 - Update build documentation
 - Update CMake build files
   - Specify static and dynamic MFC libraries in CMakeLists
   - Add new and updated source code files
 - Fix HTMLHelp project properties
   - Use solution name macros instead of direct plaintext
   - Fix HTMLDefines.h input target
 - Properly declare math header files for Pi constant (FDS.cpp, N163.cpp)