### PR TITLE
Fix DPCM phase reset bytecode write

### DIFF
--- a/Source/PatternCompiler.cpp
+++ b/Source/PatternCompiler.cpp
@@ -560,17 +560,18 @@ void CPatternCompiler::CompileData(int Track, int Pattern, int Channel)
 					}
 					break;
 				case EF_PHASE_RESET:	// // !!
-					if (ChanID != CHANID_DPCM ||
-					ChanID != CHANID_TRIANGLE ||
+					if (ChanID != CHANID_TRIANGLE ||
 					ChanID != CHANID_NOISE ||
 					ChipID != SNDCHIP_VRC7 ||
 					ChipID != SNDCHIP_S5B) {
-						WriteData(Command(CMD_EFF_PHASE_RESET));
-						WriteData(EffParam);
-					}
-					else if (ChanID == CHANID_DPCM) {
-						WriteData(Command(CMD_EFF_DPCM_PHASE_RESET));
-						WriteData(EffParam);
+						if (ChanID == CHANID_DPCM) {
+							WriteData(Command(CMD_EFF_DPCM_PHASE_RESET));
+							WriteData(EffParam);
+						}
+						else {
+							WriteData(Command(CMD_EFF_PHASE_RESET));
+							WriteData(EffParam);
+						}
 					}
 					break;
 				case EF_HARMONIC:	// // !!


### PR DESCRIPTION
This pull request aims to correctly write the DPCM phase reset bytecode ($A4). The current implementation of the bytecode compiler (PatternCompiler.cpp) makes the data write condition ambiguous, and upon further testing (while developing for bhop) shows that the bytecode gets compiled as $A3 instead of $A4.

### Changes in this PR:
- Fix DPCM phase reset bytecode write