### PR TITLE
Module interaction fixes

### DIFF
--- a/Source/APU/APU.cpp
+++ b/Source/APU/APU.cpp
@@ -609,27 +609,27 @@ void CAPUConfig::SetupMixer(
 // Device chip levels needs to be initialized first
 void CAPUConfig::SetChipLevel(chip_level_t Chip, float LeveldB, bool SurveyMix)
 {
-	// Compensate for blip_buffer output scaling differences
-	// values are derived by setting m_ChipLevels[] to 1.0
-	// and measuring the dB RMS delta between APU1 and other chips
-	// using methods described here: https://www.nesdev.org/wiki/NSFe#mixe
-	// TODO: investigate issues with rounding error
-	int16_t dblevelcorrection[CHIP_LEVEL_COUNT] {
-		0,		// APU1
-		-13,	// APU2
-		-494,	// VRC6
-		776,	// VRC7
-		-1700,	// FDS
-		869,	// MMC5
-		-1681,	// N163
-		108		// S5B
-	};
 
 	// Convert dB to linear
 	float LevelLinear = 1.0f;
 	if (SurveyMix) {
-		LevelLinear = powf(10,
-			((LeveldB + (static_cast<float>(dblevelcorrection[Chip]) / 100.0f)) +
+		// Compensate for blip_buffer output scaling differences
+		// values are derived by setting m_ChipLevels[] to 1.0
+		// and measuring the dB RMS delta between APU1 and other chips
+		// using methods described here: https://www.nesdev.org/wiki/NSFe#mixe
+		// TODO: investigate issues with rounding error
+		int16_t dblevelcorrection[CHIP_LEVEL_COUNT]{
+			0,		// APU1
+			-13,	// APU2
+			-494,	// VRC6
+			776,	// VRC7
+			-1700,	// FDS
+			869,	// MMC5
+			-1681,	// N163
+			108		// S5B
+		};
+		LevelLinear = powf(10, (LeveldB +
+			((static_cast<float>(dblevelcorrection[Chip]) / 100.0f)) +
 				(static_cast<float>(m_MixerConfig->DeviceMixOffsets[Chip]) / 10.0f)) / 20.0f);
 	}
 	else {

--- a/Source/APU/APU.cpp
+++ b/Source/APU/APU.cpp
@@ -609,7 +609,6 @@ void CAPUConfig::SetupMixer(
 // Device chip levels needs to be initialized first
 void CAPUConfig::SetChipLevel(chip_level_t Chip, float LeveldB, bool SurveyMix)
 {
-
 	// Convert dB to linear
 	float LevelLinear = 1.0f;
 	if (SurveyMix) {

--- a/Source/APU/Mixer.cpp
+++ b/Source/APU/Mixer.cpp
@@ -255,15 +255,13 @@ void CMixer::RecomputeEmuMixState()
 	chipN163.UpdateN163Filter(m_MixerConfig.N163Lowpass, m_EmulatorConfig.N163DisableMultiplexing);
 	chipFDS.UpdateFDSFilter(m_MixerConfig.FDSLowpass);
 
-	uint8_t patchdump[19 * 8];
-
-	for (int i = 0; i < 19 * 8; ++i)
-		patchdump[i] = m_EmulatorConfig.UseOPLLPatchBytes.at(i);
+	ASSERT(!m_EmulatorConfig.UseOPLLPatchBytes.empty());
+	ASSERT(m_EmulatorConfig.UseOPLLPatchBytes.size() == 19 * 8);
 
 	chipVRC7.UpdatePatchSet(
 		m_EmulatorConfig.UseOPLLPatchSet,
 		m_EmulatorConfig.UseOPLLExt,
-		patchdump);
+		&m_EmulatorConfig.UseOPLLPatchBytes[0]);
 }
 
 int CMixer::GetMeterDecayRate() const		// // // 050B

--- a/Source/APU/N163.cpp
+++ b/Source/APU/N163.cpp
@@ -86,6 +86,14 @@ uint8_t CN163::Read(uint16_t Address, bool &Mapped)
 
 void CN163::Process(uint32_t Time, Blip_Buffer& Output)
 {
+	// Mix level will dynamically change based on number of channels
+	if (!m_UseSurveyMix) {
+		int channels = m_N163.GetNumberOfChannels();
+		double N163_volume = (channels == 0) ? 1.3f : (1.5f + float(channels) / 1.5f);
+		N163_volume *= m_Attenuation;
+		m_SynthN163.volume(N163_volume * 1.1, 1600);
+	}
+
 	uint32_t now = 0;
 
 	while (true) {
@@ -192,15 +200,11 @@ void CN163::UpdateN163Filter(int CutoffHz, bool DisableMultiplex)
 
 void CN163::UpdateMixLevel(double v, bool UseSurveyMix)
 {
+	m_Attenuation = v;
+	m_UseSurveyMix = UseSurveyMix;
 	if (UseSurveyMix)
-		m_SynthN163.volume(v, 225);
-	else {
-		// Mix level will dynamically change based on number of channels
-		int channels = m_N163.GetNumberOfChannels();
-		double N163_volume = (channels == 0) ? 1.3f : (1.5f + float(channels) / 1.5f);
-		N163_volume *= v;
-		m_SynthN163.volume(N163_volume * 1.1, 1600);
-	}
+		m_SynthN163.volume(m_Attenuation, 225);
+	// Legacy mixing recalculates chip levels at runtime
 }
 
 void CN163::Log(uint16_t Address, uint8_t Value)		// // //

--- a/Source/APU/N163.h
+++ b/Source/APU/N163.h
@@ -59,6 +59,10 @@ private:
 
 	int m_CutoffHz;
 
+	// master volume attenuation
+	double m_Attenuation;
+	bool m_UseSurveyMix = false;
+
 	Namco163Audio m_N163;
 
 	Blip_Buffer m_BlipN163;

--- a/Source/APU/VRC7.cpp
+++ b/Source/APU/VRC7.cpp
@@ -57,8 +57,15 @@ void CVRC7::Reset()
 	m_iTime = 0;
 	m_BlipVRC7.clear();
 	if (m_pOPLLInt != NULL) {
+		// update patchset and OPLL type
+		OPLL_setChipType(m_pOPLLInt, ((m_UseExternalOPLLChip || m_PatchSelection > 6) ? 0 : 1));
+
+		if (m_UseExternalOPLLChip && m_PatchSet != NULL)
+			OPLL_setPatch(m_pOPLLInt, m_PatchSet);
+		else
+			OPLL_resetPatch(m_pOPLLInt, m_PatchSelection);
+
 		OPLL_reset(m_pOPLLInt);
-		// patchset and OPLL type is set in UpdatePatchSet()
 	}
 }
 
@@ -201,10 +208,7 @@ void CVRC7::UpdateMixLevel(double v, bool UseSurveyMix)
 
 void CVRC7::UpdatePatchSet(int PatchSelection, bool UseExternalOPLLChip, uint8_t* PatchSet)
 {
-	OPLL_setChipType(m_pOPLLInt, (UseExternalOPLLChip ? 0 : 1));
-
-	if (UseExternalOPLLChip)
-		OPLL_setPatch(m_pOPLLInt, PatchSet);
-	else
-		OPLL_resetPatch(m_pOPLLInt, PatchSelection);
+	m_PatchSelection = PatchSelection;
+	m_UseExternalOPLLChip = UseExternalOPLLChip;
+	m_PatchSet = PatchSet;
 }

--- a/Source/APU/VRC7.h
+++ b/Source/APU/VRC7.h
@@ -72,6 +72,13 @@ private:
 
 	double		m_DirectVolume = 1.0f;
 
+	// OPLL chip type
+	bool m_UseExternalOPLLChip = false;
+	// default OPLL patchset
+	int m_PatchSelection = 0;
+	// pointer to document OPLL patchset
+	uint8_t* m_PatchSet = NULL;
+
 	// [0..8] corresponds to the 9 channels of the YM2413. Future support for percussion mode?
 	ChannelLevelState<uint8_t> m_ChannelLevels[9];
 

--- a/Source/Compiler.cpp
+++ b/Source/Compiler.cpp
@@ -455,7 +455,8 @@ void CCompiler::ExportNSFE(LPCTSTR lpszFileName, int MachineType)		// // //
 	}
 
 	// write VRC7 chunk
-	uint8_t extOPLL = m_pDocument->GetExternalOPLLChipCheck(); iVRC7Size++;
+	// YM2413 and YMF281B are considered external OPLL
+	uint8_t extOPLL = m_pDocument->GetExternalOPLLChipCheck() || (theApp.GetSettings()->Emulation.iVRC7Patch > 6); iVRC7Size++;
 	uint8_t patchset[19 * 8];
 	if (extOPLL)
 		for (int i = 0; i < 19; i++)
@@ -721,7 +722,8 @@ void CCompiler::ExportNSF2(LPCTSTR lpszFileName, int MachineType)
 	}
 
 	// write VRC7 chunk
-	uint8_t extOPLL = m_pDocument->GetExternalOPLLChipCheck(); iVRC7Size++;
+	// YM2413 and YMF281B are considered external OPLL
+	uint8_t extOPLL = m_pDocument->GetExternalOPLLChipCheck() || (theApp.GetSettings()->Emulation.iVRC7Patch > 6); iVRC7Size++;
 	uint8_t patchset[19 * 8];
 	if (extOPLL)
 		for (int i = 0; i < 19; i++)

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -249,6 +249,7 @@ CFamiTrackerDoc::CFamiTrackerDoc() :
 
 	ResetDetuneTables();		// // //
 	ResetOPLLPatches();
+	ResetLevelOffset();
 
 	// Clear pointer arrays
 	memset(m_pTracks, 0, sizeof(CPatternData*) * MAX_TRACKS);
@@ -467,6 +468,8 @@ void CFamiTrackerDoc::DeleteContents()
 	m_vHighlight = CPatternData::DEFAULT_HIGHLIGHT;		// // //
 
 	ResetDetuneTables();		// // //
+	ResetOPLLPatches();
+	ResetLevelOffset();
 
 	// Used for loading older files
 	m_vTmpSequences.clear();		// // //
@@ -485,13 +488,7 @@ void CFamiTrackerDoc::DeleteContents()
 
 	m_csDocumentLock.Unlock();
 
-	for (int i = 0; i < 7; i++) {
-		m_iDeviceLevelOffset[i] = 0;
-	}
-
 	m_bUseSurveyMixing = false;
-
-	ResetOPLLPatches();
 
 	CDocument::DeleteContents();
 }
@@ -4529,6 +4526,12 @@ void CFamiTrackerDoc::SetLevelOffset(int device, int16_t offset)
 	if (m_iDeviceLevelOffset[device] != offset)
 		ModifyIrreversible();
 	m_iDeviceLevelOffset[device] = offset;
+}
+
+void CFamiTrackerDoc::ResetLevelOffset()
+{
+	for (int i = 0; i < 8; i++)
+		m_iDeviceLevelOffset[i] = 0;
 }
 
 uint8_t CFamiTrackerDoc::GetOPLLPatchByte(int index) const

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -4553,18 +4553,19 @@ void CFamiTrackerDoc::ResetOPLLPatches()
 
 	int DefaultPatchSetNumber = theApp.GetSettings()->Emulation.iVRC7Patch;
 
-	// YM2413 and YMF281B are considered external OPLL
-	if (DefaultPatchSetNumber > 6)
-		m_bUseExternalOPLLChip = true;
+	SetOPLLPatchSet(DefaultPatchSetNumber);
+}
 
+void CFamiTrackerDoc::SetOPLLPatchSet(int patchset)
+{
 	// Set to current default OPLL patchset
 	for (int i = 0; i < 19; i++) {
 		for (int j = 0; j < 8; j++) {
-			m_iOPLLPatchBytes[(8 * i) + j] = CAPU::OPLL_DEFAULT_PATCHES[DefaultPatchSetNumber][(8 * i) + j];
+			m_iOPLLPatchBytes[(8 * i) + j] = CAPU::OPLL_DEFAULT_PATCHES[patchset][(8 * i) + j];
 			if (i == 0)
 				m_iOPLLPatchBytes[(8 * i) + j] = 0;
 		}
-		switch (DefaultPatchSetNumber) {
+		switch (patchset) {
 		case 7:
 			m_strOPLLPatchNames[i] = CAPU::OPLL_PATCHNAME_YM2413[i];
 			break;

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -463,8 +463,6 @@ void CFamiTrackerDoc::DeleteContents()
 	m_iDetuneSemitone	 = 0;		// // // 050B
 	m_iDetuneCent		 = 0;		// // // 050B
 
-	m_bFileDnModule = false;
-
 	m_vHighlight = CPatternData::DEFAULT_HIGHLIGHT;		// // //
 
 	ResetDetuneTables();		// // //

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -161,6 +161,11 @@ std::pair<EffTable, EffTable> MakeEffectConversion(std::initializer_list<std::pa
 }
 
 // .first[] converts to 0CC, .second[] converts to FT 050B
+// 0CC for some reason a slightly different effects type order within the tracker,
+// but converts to FT 050B+ effects type order when saved to a file.
+// my guess is cross compatibility with earlier 0CC versions that didn't
+// respect FT 050B+'s effect type order? we can't do anything to change it, now.
+// https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/wiki/0CC-vs-FT-effects-type-order
 static const auto EFF_CONVERSION_050 = MakeEffectConversion({
 //	{EF_SUNSOFT_ENV_LO,		EF_SUNSOFT_ENV_TYPE},
 //	{EF_SUNSOFT_ENV_TYPE,	EF_SUNSOFT_ENV_LO},
@@ -1341,12 +1346,8 @@ bool CFamiTrackerDoc::WriteBlock_Patterns(CDocumentFile *pDocFile, const int Ver
 							int EffColumns = (m_pTracks[t]->GetEffectColumnCount(i) + 1);
 
 							for (int n = 0; n < EffColumns; n++) {
-								if (m_iFileVersion >= 0x450 && !m_bFileDnModule)
-								// Convert from 0CC-type to FamiTracker 0.5.0 beta type effect
-								// only if module is FT 0.5.0 beta
-									pDocFile->WriteBlockChar(EFF_CONVERSION_050.second[Note->EffNumber[n]]);		// // // 050B
-								else
-									pDocFile->WriteBlockChar(Note->EffNumber[n]);
+								// write 0CC effect type order as FamiTracker 0.5.0 beta+ effect type order
+								pDocFile->WriteBlockChar(EFF_CONVERSION_050.second[Note->EffNumber[n]]);		// // // 050B
 								pDocFile->WriteBlockChar(Note->EffParam[n]);
 							}
 						}
@@ -1637,10 +1638,8 @@ BOOL CFamiTrackerDoc::OpenDocumentOld(CFile *pOpenFile)
 							if (Note->Vol == 0)
 								Note->Vol = MAX_VOLUME;
 							if (Note->EffNumber[0] < EF_COUNT)		// // //
-								if (m_iFileVersion >= 0x450 && !m_bFileDnModule)
-									// Convert from FamiTracker 0.5.0 beta type to 0CC-type effect
-									// only if module is FT 0.5.0 beta
-									Note->EffNumber[0] = EFF_CONVERSION_050.first[Note->EffNumber[0]];
+								// read FamiTracker 0.5.0 beta+ effect type order as 0CC effect type order
+								Note->EffNumber[0] = EFF_CONVERSION_050.first[Note->EffNumber[0]];
 						}
 					}
 				}
@@ -2452,11 +2451,10 @@ void CFamiTrackerDoc::ReadBlock_Patterns(CDocumentFile *pDocFile, const int Vers
 				}
 
 				// TODO: Dn-FamiTracker compatibility modes
-				if (m_iFileVersion >= 0x450 && !m_bFileDnModule) {		// // // 050B
+				if (m_iFileVersion < 0x450 || m_bFileDnModule) {		// // // 050B
 					for (auto &x : Note->EffNumber)
 						if (x < EF_COUNT)
-							// Convert from FamiTracker 0.5.0 beta type to 0CC-type effect
-							// only if module is FT 0.5.0 beta
+							// read FamiTracker 0.5.0 beta+ effect type order as 0CC effect type order
 							x = EFF_CONVERSION_050.first[x];
 				}
 				/*

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -160,6 +160,7 @@ std::pair<EffTable, EffTable> MakeEffectConversion(std::initializer_list<std::pa
 	return std::make_pair(forward, backward);
 }
 
+// .first[] converts to 0CC, .second[] converts to FT 050B
 static const auto EFF_CONVERSION_050 = MakeEffectConversion({
 //	{EF_SUNSOFT_ENV_LO,		EF_SUNSOFT_ENV_TYPE},
 //	{EF_SUNSOFT_ENV_TYPE,	EF_SUNSOFT_ENV_LO},
@@ -1340,8 +1341,9 @@ bool CFamiTrackerDoc::WriteBlock_Patterns(CDocumentFile *pDocFile, const int Ver
 							int EffColumns = (m_pTracks[t]->GetEffectColumnCount(i) + 1);
 
 							for (int n = 0; n < EffColumns; n++) {
-								if (m_iFileVersion < 0x450 && !m_bFileDnModule)
+								if (m_iFileVersion >= 0x450 && !m_bFileDnModule)
 								// Convert from 0CC-type to FamiTracker 0.5.0 beta type effect
+								// only if module is FT 0.5.0 beta
 									pDocFile->WriteBlockChar(EFF_CONVERSION_050.second[Note->EffNumber[n]]);		// // // 050B
 								else
 									pDocFile->WriteBlockChar(Note->EffNumber[n]);
@@ -1635,8 +1637,9 @@ BOOL CFamiTrackerDoc::OpenDocumentOld(CFile *pOpenFile)
 							if (Note->Vol == 0)
 								Note->Vol = MAX_VOLUME;
 							if (Note->EffNumber[0] < EF_COUNT)		// // //
-								if (m_iFileVersion < 0x450 && !m_bFileDnModule)
+								if (m_iFileVersion >= 0x450 && !m_bFileDnModule)
 									// Convert from FamiTracker 0.5.0 beta type to 0CC-type effect
+									// only if module is FT 0.5.0 beta
 									Note->EffNumber[0] = EFF_CONVERSION_050.first[Note->EffNumber[0]];
 						}
 					}
@@ -2449,10 +2452,11 @@ void CFamiTrackerDoc::ReadBlock_Patterns(CDocumentFile *pDocFile, const int Vers
 				}
 
 				// TODO: Dn-FamiTracker compatibility modes
-				if (m_iFileVersion < 0x450 && !m_bFileDnModule) {		// // // 050B
+				if (m_iFileVersion >= 0x450 && !m_bFileDnModule) {		// // // 050B
 					for (auto &x : Note->EffNumber)
 						if (x < EF_COUNT)
 							// Convert from FamiTracker 0.5.0 beta type to 0CC-type effect
+							// only if module is FT 0.5.0 beta
 							x = EFF_CONVERSION_050.first[x];
 				}
 				/*

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -243,7 +243,9 @@ CFamiTrackerDoc::CFamiTrackerDoc() :
 	m_pInstrumentManager(new CInstrumentManager(this)),
 	m_pBookmarkManager(new CBookmarkManager(MAX_TRACKS)),
 	m_bUseExternalOPLLChip(false),
-	m_bUseSurveyMixing(false)
+	m_bUseSurveyMixing(false),
+	m_iPlaybackRate(0),
+	m_iPlaybackRateType(0)
 {
 	// Initialize document object
 

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -4561,9 +4561,9 @@ void CFamiTrackerDoc::ResetOPLLPatches()
 	// Set to current default OPLL patchset
 	for (int i = 0; i < 19; i++) {
 		for (int j = 0; j < 8; j++) {
+			m_iOPLLPatchBytes[(8 * i) + j] = CAPU::OPLL_DEFAULT_PATCHES[DefaultPatchSetNumber][(8 * i) + j];
 			if (i == 0)
 				m_iOPLLPatchBytes[(8 * i) + j] = 0;
-			m_iOPLLPatchBytes[(8 * i) + j] = CAPU::OPLL_DEFAULT_PATCHES[DefaultPatchSetNumber][(8 * i) + j];
 		}
 		switch (DefaultPatchSetNumber) {
 		case 7:

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -270,6 +270,7 @@ public:
 	uint8_t			GetOPLLPatchByte(int index) const;
 	void			SetOPLLPatchByte(int index, uint8_t data);
 	void			ResetOPLLPatches();
+	void			SetOPLLPatchSet(int patchset);
 
 	std::string		GetOPLLPatchName(int index) const;
 	void			SetOPLLPatchName(int index, std::string PatchName);

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -265,6 +265,7 @@ public:
 
 	int16_t			GetLevelOffset(int device) const;
 	void			SetLevelOffset(int device, int16_t offset);
+	void			ResetLevelOffset();
 
 	uint8_t			GetOPLLPatchByte(int index) const;
 	void			SetOPLLPatchByte(int index, uint8_t data);

--- a/Source/InstrumentEditorVRC7.cpp
+++ b/Source/InstrumentEditorVRC7.cpp
@@ -90,6 +90,11 @@ BOOL CInstrumentEditorVRC7::OnInitDialog()
 	// Get active document
 	m_pDocument = GetDocument();
 
+	// initialize default patchset if it hasn't been already
+	// FIXME: initialize immediately after CConfigEmulation::OnApply()
+	if (!m_pDocument->GetExternalOPLLChipCheck())
+		m_pDocument->SetOPLLPatchSet(theApp.GetSettings()->Emulation.iVRC7Patch);
+
 	// fetch patch names and bytes
 	for (int i = 0; i < 19; i++) {
 		for (int j = 0; j < 8; j++)

--- a/Source/InstrumentEditorVRC7.cpp
+++ b/Source/InstrumentEditorVRC7.cpp
@@ -86,14 +86,8 @@ BOOL CInstrumentEditorVRC7::OnInitDialog()
 	CComboBox* pPatchBox = static_cast<CComboBox*>(GetDlgItem(IDC_PATCH));
 	CString Text;
 
-
 	// Get active document
 	m_pDocument = GetDocument();
-
-	// initialize default patchset if it hasn't been already
-	// FIXME: initialize immediately after CConfigEmulation::OnApply()
-	if (!m_pDocument->GetExternalOPLLChipCheck())
-		m_pDocument->SetOPLLPatchSet(theApp.GetSettings()->Emulation.iVRC7Patch);
 
 	// fetch patch names and bytes
 	for (int i = 0; i < 19; i++) {

--- a/Source/ModulePropertiesDlg.cpp
+++ b/Source/ModulePropertiesDlg.cpp
@@ -314,7 +314,6 @@ BOOL CModulePropertiesDlg::OnInitDialog()
 		}
 	else {
 		// initialize default patchset if it hasn't been already
-		// FIXME: initialize immediately after CConfigEmulation::OnApply()
 		m_pDocument->SetOPLLPatchSet(theApp.GetSettings()->Emulation.iVRC7Patch);
 		for (int i = 0; i < 19; ++i) {
 			for (int j = 0; j < 8; j++)
@@ -407,8 +406,6 @@ void CModulePropertiesDlg::OnBnClickedOk()
 			m_pDocument->SetOPLLPatchName(i, m_strOPLLPatchNames[i]);
 		}
 	else
-		// initialize default patchset if it hasn't been already
-		// FIXME: initialize immediately after CConfigEmulation::OnApply()
 		m_pDocument->SetOPLLPatchSet(theApp.GetSettings()->Emulation.iVRC7Patch);
 
 	if (pMainFrame->GetSelectedTrack() != m_iSelectedSong)

--- a/Source/ModulePropertiesDlg.cpp
+++ b/Source/ModulePropertiesDlg.cpp
@@ -980,10 +980,10 @@ CString CModulePropertiesDlg::PatchBytesToText(uint8_t* patchbytes)
 	return patchtxt;
 }
 
-uint8_t CModulePropertiesDlg::PatchTextToBytes(LPCTSTR pString, int index)
+void CModulePropertiesDlg::PatchTextToBytes(LPCTSTR pString, int index)
 {
 	std::string str(pString);
-	uint8_t patchbytes[8]{};
+	std::vector<uint8_t> patchbytes(8, 0);
 
 	// Convert to register values
 	std::istringstream values(str);
@@ -994,10 +994,8 @@ uint8_t CModulePropertiesDlg::PatchTextToBytes(LPCTSTR pString, int index)
 		int value = CSequenceInstrumentEditPanel::ReadStringValue(*begin++, false);		// // //
 		if (value < 0) value = 0;
 		if (value > 0xFF) value = 0xFF;
-		patchbytes[i] = value;
+		m_iOPLLPatchBytes[(8 * index) + i] = value;
 	}
-	
-	return patchbytes[index];
 }
 
 void CModulePropertiesDlg::OnBnClickedExternalOpll()
@@ -1012,9 +1010,7 @@ void CModulePropertiesDlg::OpllPatchByteEdit(int patchnum)
 {
 	CString str;
 	m_cOPLLPatchBytesEdit[patchnum].GetWindowText(str);
-
-	for (int i = 0; i < 8; i++)
-		m_iOPLLPatchBytes[(8 * 1) + i] = PatchTextToBytes(str, i);
+	PatchTextToBytes(str, patchnum);
 
 	updateExternallOPLLUI(patchnum, false);
 }

--- a/Source/ModulePropertiesDlg.cpp
+++ b/Source/ModulePropertiesDlg.cpp
@@ -304,9 +304,23 @@ BOOL CModulePropertiesDlg::OnInitDialog()
 		m_cOPLLPatchLabel[i].SubclassDlgItem(IDC_STATIC_PATCH[i], this);
 		m_cOPLLPatchBytesEdit[i].SubclassDlgItem(IDC_OPLL_PATCHBYTE[i], this);
 		m_cOPLLPatchNameEdit[i].SubclassDlgItem(IDC_OPLL_PATCHNAME[i], this);
-		for (int j = 0; j < 8; j++)
-			m_iOPLLPatchBytes[(8 * i) + j] = m_pDocument->GetOPLLPatchByte((8 * i) + j);
-		m_strOPLLPatchNames[i] = m_pDocument->GetOPLLPatchName(i);
+	}
+
+	if (m_bExternalOPLL)
+		for (int i = 0; i < 19; ++i) {
+			for (int j = 0; j < 8; j++)
+				m_iOPLLPatchBytes[(8 * i) + j] = m_pDocument->GetOPLLPatchByte((8 * i) + j);
+			m_strOPLLPatchNames[i] = m_pDocument->GetOPLLPatchName(i);
+		}
+	else {
+		// initialize default patchset if it hasn't been already
+		// FIXME: initialize immediately after CConfigEmulation::OnApply()
+		m_pDocument->SetOPLLPatchSet(theApp.GetSettings()->Emulation.iVRC7Patch);
+		for (int i = 0; i < 19; ++i) {
+			for (int j = 0; j < 8; j++)
+				m_iOPLLPatchBytes[(8 * i) + j] = m_pDocument->GetOPLLPatchByte((8 * i) + j);
+			m_strOPLLPatchNames[i] = m_pDocument->GetOPLLPatchName(i);
+		}
 	}
 
 	// Update UI after, since this updates all components at once,
@@ -386,11 +400,16 @@ void CModulePropertiesDlg::OnBnClickedOk()
 	// Externall OPLL
 	m_pDocument->SetExternalOPLLChipCheck(m_bExternalOPLL);
 
-	for (int i = 0; i < 19; i++) {
-		for (int j = 0; j < 8; j++)
-			m_pDocument->SetOPLLPatchByte((8 * i) + j, m_iOPLLPatchBytes[(8 * i) + j]);
-		m_pDocument->SetOPLLPatchName(i, m_strOPLLPatchNames[i]);
-	}
+	if (m_bExternalOPLL)
+		for (int i = 0; i < 19; i++) {
+			for (int j = 0; j < 8; j++)
+				m_pDocument->SetOPLLPatchByte((8 * i) + j, m_iOPLLPatchBytes[(8 * i) + j]);
+			m_pDocument->SetOPLLPatchName(i, m_strOPLLPatchNames[i]);
+		}
+	else
+		// initialize default patchset if it hasn't been already
+		// FIXME: initialize immediately after CConfigEmulation::OnApply()
+		m_pDocument->SetOPLLPatchSet(theApp.GetSettings()->Emulation.iVRC7Patch);
 
 	if (pMainFrame->GetSelectedTrack() != m_iSelectedSong)
 		pMainFrame->SelectTrack(m_iSelectedSong);

--- a/Source/ModulePropertiesDlg.h
+++ b/Source/ModulePropertiesDlg.h
@@ -85,7 +85,7 @@ public:
 	void updateDeviceMixOffsetUI(int device, bool renderText = true);
 	void updateExternallOPLLUI(int patchnum, bool renderText = true);
 	CString PatchBytesToText(uint8_t* patchbytes);
-	uint8_t PatchTextToBytes(LPCTSTR pString, int index);
+	void PatchTextToBytes(LPCTSTR pString, int index);
 	void OffsetSlider(int device, int pos);
 	void DeviceOffsetEdit(int device);
 	void OpllPatchByteEdit(int patchnum);

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -350,11 +350,16 @@ private:
 	CSoundStream		*m_pSoundStream;
 	CVisualizerWnd		*m_pVisualizerWnd;
 	CAPU				*m_pAPU;
+
+	// Emulation objects
 	bool UseExtOPLL;
-	std::vector<int16_t> DeviceMixOffset;
-	bool UseSurveyMix;
+	int OPLLDefaultPatchSet;
 	std::vector<uint8_t> OPLLHardwarePatchBytes;
 	std::vector<std::string> OPLLHardwarePatchNames;
+
+	// Mixer objects
+	bool UseSurveyMix;
+	std::vector<int16_t> DeviceMixOffset;
 
 
 	const CDSample		*m_pPreviewSample;


### PR DESCRIPTION
This pull request aims to fix module breaking bugs found in [version 0.5.0.0](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/releases/tag/Dn0.5.0.0).

This pull request iterates upon PR #156.

### Changes in this PR:
 - Fix effects conversion logic
   - Fixes #184.
 - Fix OPLL dialog only affecting first byte patch
   - Fixes #176.
 - Fix N163 mixing channel count data race
   - Fixes #174.
 - Fully initialize device level offset object
 - Prevent module compatibility mode reinitialization
   - Fixes #184.
 - Reinitialize OPLL patchset
   - Fixes #203.
 - Initialize PlaybackRate and PlaybackRateType
   - Addresses #202.