### PR TITLE
Improvements to automated builds

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,28 @@
+name: build-artifact
+on: push
+
+jobs:
+  build-matrix:
+    runs-on: windows-2022
+    strategy:
+      matrix:
+        platform: [x64, Win32]
+        configuration: [Release, Debug]
+    steps:
+      - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
+      - name: Build program
+        shell: cmd
+        run: |
+          for /f "tokens=*" %%a in ('git describe --tags') do (set commithash=%%a)
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsamd64_x86.bat"
+          call msbuild -m:5 -nologo -p:Configuration="${{ matrix.configuration }}" -p:Platform="${{ matrix.platform }}"
+          if %ERRORLEVEL%==1 exit %ERRORLEVEL%
+          call release.bat ${{ matrix.configuration }} ${{ matrix.platform }} %commithash%_%GITHUB_RUN_ID%
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@master
+        with:
+          name: build-artifacts
+          path: distribute/*.7z

--- a/Dn-FT_VS_Dependencies.vsconfig
+++ b/Dn-FT_VS_Dependencies.vsconfig
@@ -22,7 +22,6 @@
     "Microsoft.VisualStudio.Component.VC.ATLMFC.Spectre",
     "Microsoft.VisualStudio.Component.VC.ASAN",
     "Microsoft.VisualStudio.Component.Windows10SDK.20348",
-    "Microsoft.VisualStudio.Component.Windows11SDK.22621",
     "Microsoft.Component.VC.Runtime.UCRTSDK",
     "Microsoft.VisualStudio.Workload.NativeDesktop",
     "Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre"

--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -24,7 +24,7 @@
     <Keyword>MFCProj</Keyword>
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <ProjectName>Dn-FamiTracker</ProjectName>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/Dn_main_appveyor.yml
+++ b/Dn_main_appveyor.yml
@@ -3,25 +3,24 @@ pull_requests:
   do_not_increment_build_number: true
 branches:
   only:
-  - master
+  - main
 skip_tags: true
 skip_branch_with_pr: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 platform:
 - x64
 - Win32
 configuration:
 - Release
 - Debug
-shallow_clone: true
-clone_depth: 5
+shallow_clone: false
 build:
   project: Dn-FamiTracker.sln
   parallel: true
   verbosity: minimal
 after_build:
-- cmd: >-
-    call release.bat %configuration% %platform% %APPVEYOR_REPO_COMMIT%_%APPVEYOR_BUILD_VERSION%
+- cmd: for /f "tokens=*" %%a in ('git describe --tags') do (set commithash=%%a)
+- cmd: call release.bat %configuration% %platform% %commithash%_%APPVEYOR_BUILD_VERSION%
 artifacts:
 - path: distribute\*.7z
   name: 7z

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Legacy Dev Builds: [![AppVeyor](https://img.shields.io/appveyor/build/Gumball241
 
 Notice: Due to delayed Appveyor reintegration, builds for commits `dc4c9e8` to `2141360` are not available.
 
+Notice: Due to delayed branch renaming, builds for commits `bc46c86` to `a591d15` are not available.
+
 ## License
 
 The application and the source code are distributed under the GNU GPL 2 license or any later version, but depends on FDS and N163 sound emulation only under the GPL v3. The original NSF driver source code is unlicensed. 0CC FT NSF driver changes are licensed under GPL v2. Dn-FT NSF driver changes are licensed under MIT-0.

--- a/Source/libsamplerate/libsamplerate.vcxproj
+++ b/Source/libsamplerate/libsamplerate.vcxproj
@@ -23,7 +23,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{5b4c1aa7-4ae9-4ff2-a7e6-8eee50edc6e2}</ProjectGuid>
     <RootNamespace>libsamplerate</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,7 +20,10 @@ To edit and/or build the source, you may use Visual Studio 2022, or alternativel
 - [HTML Help Workshop](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/htmlhelp/microsoft-html-help-downloads) to build the manual. Note that HTML Help Workshop is no longer supported and thus no longer available to download on Microsoft's website. [Link to archived download.](https://web.archive.org/web/20200720082840/http://download.microsoft.com/download/0/A/9/0A939EF6-E31C-430F-A3DF-DFAE7960D564/htmlhelp.exe)
 - For any IDE that supports building via CMake:
   - CMake
-  - The latest MSVC build tools (may be from VS Installer or from other sources)
+  - The latest MSVC build tools 
+	  - may be installed by VS Installer or by other sources
+  - Windows 10 SDK version 2104 (10.0.20348.0)
+	  - may be installed by VS Installer or by other sources
   - These dependencies can be installed through the Visual Studio Installer:
      - C++ MFC for latest v143 build tools (x86 & x64)
      - C++ ATL for latest v143 build tools (x86 & x64)

--- a/hlp/hlp.vcxproj
+++ b/hlp/hlp.vcxproj
@@ -23,13 +23,13 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{afd2f6e3-e658-4a1b-a691-8f10a858321b}</ProjectGuid>
     <RootNamespace>hlp</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -42,7 +42,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Utility</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">

--- a/release.bat
+++ b/release.bat
@@ -18,7 +18,7 @@ goto endfile
 if "%~3"=="" goto compileversion
 
 cd  %2/%1/
-call 7z a -t7z -mx=9 -mmt=3 -m0=LZMA2:d=26:fb=128 -ms=on ..\..\distribute\Dn-FamiTracker_"%~3"_%conf_name%_"%~1".7z Dn-FamiTracker.exe Dn-FamiTracker.chm Dn-FamiTracker.pdb vc142.pdb ..\..\changelog.txt ..\..\demo
+call 7z a -t7z -mx=9 -mmt=3 -m0=LZMA2:d=26:fb=128 -ms=on ..\..\distribute\Dn-FamiTracker_"%~3"_%conf_name%_"%~1".7z Dn-FamiTracker.exe Dn-FamiTracker.chm Dn-FamiTracker.pdb vc143.pdb ..\..\changelog.txt ..\..\demo
 cd ..\..
 goto endfile
 
@@ -29,6 +29,6 @@ for /F "tokens=1,2,3,4,5 delims=, " %%A in (Dn-FamiTracker.rc) do (
 	)
 )
 cd  %2/%1/
-call 7z a -t7z -mx=9 -mmt=3 -m0=LZMA2:d=26:fb=128 -ms=on ..\..\distribute\Dn-FamiTracker_%version%_%conf_name%_"%~1".7z Dn-FamiTracker.exe Dn-FamiTracker.chm Dn-FamiTracker.pdb vc142.pdb ..\..\changelog.txt ..\..\demo
+call 7z a -t7z -mx=9 -mmt=3 -m0=LZMA2:d=26:fb=128 -ms=on ..\..\distribute\Dn-FamiTracker_%version%_%conf_name%_"%~1".7z Dn-FamiTracker.exe Dn-FamiTracker.chm Dn-FamiTracker.pdb vc143.pdb ..\..\changelog.txt ..\..\demo
 cd ..\..
 :endfile


### PR DESCRIPTION
This pull request aims to fix Appveyor builds not including the VC++ program database file due to #186.
This pull request also aims to improve Appveyor build versioning to be more concise, and also implementing Github Actions.

### Changes in this PR:
 - Update VC++ program database file name in build script
 - Improve Appveyor build version info
 - Add Github Actions for build artifacts
 - Use Windows 10 SDK version 2104 (10.0.20348.0) to avoid unexpected linker failure
