### PR TITLE
Fix version checker repository link

### DIFF
--- a/Dn-FamiTracker.rc
+++ b/Dn-FamiTracker.rc
@@ -2947,7 +2947,7 @@ BEGIN
     ID_EDIT_PASTEINSERT     "Pasted notes will be inserted above the destination\nPaste Insert"
     ID_PASTESPECIAL_CURSOR  "Paste operations occur at the cursor\nCursor"
     ID_PASTESPECIAL_SELECTION 
-                            "Go to https://github.com/Gumball2415/Dn-FamiTracker"
+                            "Paste operations occur at the start of selection\nSelection"
     ID_PASTESPECIAL_FILL    "Paste operations loop throughout the current selection\nFill"
     ID_CLEANUP_POPULATEUNIQUEPATTERNS 
                             "Copy a unique pattern for each frame\nPopulate Unique Patterns"

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ Dn-Famitracker is a fork of 0CC-FamiTracker that incorporates numerous fixes and
 
 ## Downloads
 
-Download releases: [![GitHub all releases](https://img.shields.io/github/downloads/Gumball2415/Dn-FamiTracker/total?logo=github&style=flat-square)](https://github.com/Gumball2415/Dn-FamiTracker/releases)
+Download releases: [![GitHub all releases](https://img.shields.io/github/downloads/Dn-Programming-Core-Management/Dn-FamiTracker/total?logo=github&style=flat-square)](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/releases)
 
 Development builds: [![AppVeyor](https://img.shields.io/appveyor/build/Gumball2415/dn-famitracker?logo=appveyor&style=flat-square)](https://ci.appveyor.com/project/Gumball2415/dn-famitracker/history)
+
+Github Actions automated builds: [![GitHub Actions](https://img.shields.io/github/actions/workflow/status/Dn-Programming-Core-Management/Dn-FamiTracker/build-artifact.yml?style=flat-square)](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/actions/workflows/build-artifact.yml)
+
+Github Actions automated release builds: [![GitHub](https://img.shields.io/github/actions/workflow/status/Dn-Programming-Core-Management/Dn-FamiTracker/build-release-artifact.yml?style=flat-square)](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/actions/workflows/build-release-artifact.yml)
 
 Legacy Dev Builds: [![AppVeyor](https://img.shields.io/appveyor/build/Gumball2415/dn-famitracker-legacy?logo=appveyor&style=flat-square)](https://ci.appveyor.com/project/Gumball2415/dn-famitracker-legacy/history)
 

--- a/Source/VersionChecker.cpp
+++ b/Source/VersionChecker.cpp
@@ -44,7 +44,7 @@ namespace {
 			hOpen = InternetOpenW(L"Dn_FamiTracker", INTERNET_OPEN_TYPE_PRECONFIG, NULL, NULL, 0);
 			hConnect = InternetConnectW(hOpen, L"api.github.com",
 				INTERNET_DEFAULT_HTTPS_PORT, L"", L"", INTERNET_SERVICE_HTTP, 0, 0);
-			hRequest = HttpOpenRequestW(hConnect, L"GET", L"/repos/Gumball2415/Dn-FamiTracker/releases",
+			hRequest = HttpOpenRequestW(hConnect, L"GET", L"/repos/Dn-Programming-Core-Management/Dn-FamiTracker/releases",
 				L"HTTP/1.0", NULL, rgpszAcceptTypes,
 				INTERNET_FLAG_RELOAD | INTERNET_FLAG_SECURE | INTERNET_FLAG_NO_CACHE_WRITE, NULL);
 		}


### PR DESCRIPTION
This pull request aims to fix the version checker repository link.

Dn-FamiTracker versions 0.5.0.1 and below checks for updates from `Gumball2415/Dn-FamiTracker`. This was the original repository location before it was moved to  `Dn-Programming-Core-Management/Dn-FamiTracker`.

Ever since I opened a new fork under my account, I broke the redirecting functionality that seems to exist in the years since the repository transferred to @Dn-Programming-Core-Management.
