### PR TITLE
Module interaction and state fixes

### DIFF
--- a/Source/APU/2A03.cpp
+++ b/Source/APU/2A03.cpp
@@ -198,16 +198,16 @@ int C2A03::GetChannelLevelRange(int Channel) const
 }
 
 
-void C2A03::UpdateMixingAPU1(double v) {
+void C2A03::UpdateMixingAPU1(double v, bool UseSurveyMix) {
 	// NSFPlay output waveform ranges from 0 - 8191
-	// should not affect legacy mixing
-	Synth2A03SS.volume(v, 8191);
+	// legacy mixing absolutely requires the range 10000
+	Synth2A03SS.volume(v, UseSurveyMix ? 8191 : 10000);
 }
 
-void C2A03::UpdateMixingAPU2(double v) {
+void C2A03::UpdateMixingAPU2(double v, bool UseSurveyMix) {
 	// NSFPlay output waveform ranges from 0 - 8191
-	// should not affect legacy mixing
-	Synth2A03TND.volume(v, 8191);
+	// legacy mixing absolutely requires the range 10000
+	Synth2A03TND.volume(v, UseSurveyMix ? 8191 : 10000);
 }
 
 void C2A03::ClockSequence()

--- a/Source/APU/2A03.h
+++ b/Source/APU/2A03.h
@@ -99,8 +99,8 @@ public:
 	int GetChannelLevelRange(int Channel) const override;
 
 public:
-	void UpdateMixingAPU1(double v);
-	void UpdateMixingAPU2(double v);
+	void UpdateMixingAPU1(double v, bool UseSurveyMix = false);
+	void UpdateMixingAPU2(double v, bool UseSurveyMix = false);
 
 	void	ClockSequence();		// // //
 	

--- a/Source/APU/FDS.cpp
+++ b/Source/APU/FDS.cpp
@@ -232,12 +232,7 @@ void CFDS::UpdateMixLevel(double v, bool UseSurveyMix)
 	// (m_SynthFDS: FdsAudio) used to generate output samples between [0..63] inclusive,
 	// but was changed to  [0 .. 63*1152] inclusive to prevent quantization at low volumes.
 
-	if (UseSurveyMix)
-		m_SynthFDS.volume(v, 63 * 1152);
-	else
-		// The following mixing levels match nsfplay's FDS output,
-		// using 2A03 Pulse as a baseline.
-		m_SynthFDS.volume(v * 1.122f, 256 * 1152);
+	m_SynthFDS.volume(UseSurveyMix ? v : (v * 1.122f), UseSurveyMix ? (63 * 1152) : (256 * 1152));
 }
 
 /// Input:

--- a/Source/APU/Mixer.cpp
+++ b/Source/APU/Mixer.cpp
@@ -148,7 +148,7 @@ void CMixer::SetChipLevel(chip_level_t Chip, float Level)
 
 float CMixer::GetAttenuation(bool UseSurveyMix) const
 {
-	float Attenuation = 1.0f;
+	float ATTENUATION_2A03 = 1.0f;
 
 	if (!UseSurveyMix) {
 		const float ATTENUATION_VRC6 = 0.80f;
@@ -161,22 +161,17 @@ float CMixer::GetAttenuation(bool UseSurveyMix) const
 		// Increase headroom if some expansion chips are enabled
 
 		if (m_iExternalChip & SNDCHIP_VRC6)
-			Attenuation *= ATTENUATION_VRC6;
-
+			ATTENUATION_2A03 *= ATTENUATION_VRC6;
 		if (m_iExternalChip & SNDCHIP_VRC7)
-			Attenuation *= ATTENUATION_VRC7;
-
+			ATTENUATION_2A03 *= ATTENUATION_VRC7;
 		if (m_iExternalChip & SNDCHIP_FDS)
-			Attenuation *= ATTENUATION_FDS;
-
+			ATTENUATION_2A03 *= ATTENUATION_FDS;
 		if (m_iExternalChip & SNDCHIP_MMC5)
-			Attenuation *= ATTENUATION_MMC5;
-
+			ATTENUATION_2A03 *= ATTENUATION_MMC5;
 		if (m_iExternalChip & SNDCHIP_N163)
-			Attenuation *= ATTENUATION_N163;
-
+			ATTENUATION_2A03 *= ATTENUATION_N163;
 		if (m_iExternalChip & SNDCHIP_S5B)		// // // 050B
-			Attenuation *= ATTENUATION_S5B;
+			ATTENUATION_2A03 *= ATTENUATION_S5B;
 	}
 	else {
 		// attenuation scaling is exponential based on total chips used
@@ -188,10 +183,10 @@ float CMixer::GetAttenuation(bool UseSurveyMix) const
 		if (m_iExternalChip & SNDCHIP_N163) TotalChipsUsed++;
 		if (m_iExternalChip & SNDCHIP_S5B) TotalChipsUsed++;
 
-		Attenuation *= static_cast<float>(1.0 / (float)TotalChipsUsed);
+		ATTENUATION_2A03 *= static_cast<float>(1.0 / (float)TotalChipsUsed);
 	}
 
-	return Attenuation;
+	return ATTENUATION_2A03;
 }
 
 void CMixer::RecomputeEmuMixState()
@@ -229,8 +224,8 @@ void CMixer::RecomputeEmuMixState()
 
 	// Maybe the range argument, as well as the constant factor in the volume,
 	// should be supplied by the CSoundChip2 subclass rather than CMixer.
-	chip2A03.UpdateMixingAPU1(Volume * m_fLevelAPU1);
-	chip2A03.UpdateMixingAPU2(Volume * m_fLevelAPU2);
+	chip2A03.UpdateMixingAPU1(Volume * m_fLevelAPU1, UseSurveyMixing);
+	chip2A03.UpdateMixingAPU2(Volume * m_fLevelAPU2, UseSurveyMixing);
 	chipFDS.UpdateMixLevel(Volume * m_fLevelFDS, UseSurveyMixing);
 	chipN163.UpdateMixLevel(Volume * m_fLevelN163, UseSurveyMixing);
 

--- a/Source/APU/VRC7.cpp
+++ b/Source/APU/VRC7.cpp
@@ -203,7 +203,7 @@ void CVRC7::UpdateMixLevel(double v, bool UseSurveyMix)
 	SetDirectVolume(UseSurveyMix ? v : (v * AMPLIFY));
 	
 	// emu2413's waveform output ranges from -4095...4095
-	m_SynthVRC7.volume(v, 8191);
+	m_SynthVRC7.volume(v, UseSurveyMix ? 8191 : 10000);
 }
 
 void CVRC7::UpdatePatchSet(int PatchSelection, bool UseExternalOPLLChip, uint8_t* PatchSet)

--- a/Source/Compiler.cpp
+++ b/Source/Compiler.cpp
@@ -1482,7 +1482,7 @@ void CCompiler::CreateHeader(stNSFHeader *pHeader, int MachineType, unsigned int
 	// If speed is default, write correct NTSC/PAL speed periods
 	// else, set the same custom speed for both
 	SpeedNTSC = (Speed == 0) ? 1000000 / CAPU::FRAME_RATE_NTSC : 1000000 / Speed;
-	SpeedPAL = (Speed == 0) ? 1000000 / CAPU::FRAME_RATE_NTSC : 1000000 / Speed;
+	SpeedPAL = (Speed == 0) ? 1000000 / CAPU::FRAME_RATE_PAL : 1000000 / Speed;
 
 	memset(pHeader, 0, 0x80);
 
@@ -1564,7 +1564,7 @@ void CCompiler::CreateNSFeHeader(stNSFeHeader *pHeader, int MachineType)		// // 
 	unsigned int SpeedPAL, SpeedNTSC, Speed;
 	Speed = m_pDocument->GetEngineSpeed();
 	SpeedNTSC = (Speed == 0) ? 1000000 / CAPU::FRAME_RATE_NTSC : 1000000 / Speed;
-	SpeedPAL = (Speed == 0) ? 1000000 / CAPU::FRAME_RATE_NTSC : 1000000 / Speed;
+	SpeedPAL = (Speed == 0) ? 1000000 / CAPU::FRAME_RATE_PAL : 1000000 / Speed;
 
 	pHeader->InfoSize = 12;
 	pHeader->BankSize = 8;

--- a/Source/ExportDialog.cpp
+++ b/Source/ExportDialog.cpp
@@ -166,10 +166,14 @@ BOOL CExportDialog::OnInitDialog()
 
 	// Add selections for each custom plugin name
 	CStringArray names;
-	theApp.GetCustomExporters()->GetNames( names );
+	CCustomExporters* pExporters = theApp.GetCustomExporters();
 
-	for( int i = 0; i < names.GetCount(); ++i )
-		pTypeBox->AddString( names[ i ] );
+	if (pExporters) {
+		pExporters->GetNames(names);
+
+		for (int i = 0; i < names.GetCount(); ++i)
+			pTypeBox->AddString(names[i]);
+	}
 
 	// Set default selection
 	pTypeBox->SetCurSel(m_iExportOption);

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -455,11 +455,11 @@ void CFamiTrackerApp::OnRecentFilesClear()		// // //
 
 void CFamiTrackerApp::OnUpdateRecentFiles(CCmdUI *pCmdUI)		// // //
 {
-	// https://www.codeguru.com/cpp/controls/menu/miscellaneous/article.php/c167
+	// https://web.archive.org/web/20190906190854/https://www.codeguru.com/cpp/controls/menu/miscellaneous/article.php/c167/MRU-list-in-a-submenu-the-MFC-bug-and-how-to-correct-it.htm
 	// updating a submenu?
 	if (pCmdUI->m_pSubMenu != NULL) return;
 
-	m_pRecentFileList->UpdateMenu(pCmdUI);
+	CWinApp::OnUpdateRecentFileMenu(pCmdUI);
 }
 
 void CFamiTrackerApp::ShutDownSynth()

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -159,7 +159,11 @@ BOOL CFamiTrackerApp::InitInstance()
 	GetModuleFileName(NULL, pathToPlugins, MAX_PATH);
 	PathRemoveFileSpec(pathToPlugins);
 	PathAppend(pathToPlugins, _T("\\Plugins"));
-	m_customExporters = new CCustomExporters( pathToPlugins );
+
+	// https://github.com/eatscrayon/Dn-FamiTracker-dll-hijack
+	// custom exporters are disabled until a better method is found.
+	// this is a huge security risk!
+	//m_customExporters = new CCustomExporters( pathToPlugins );
 
 	// Load custom accelerator
 	m_pAccel = new CAccelerator();

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -391,8 +391,7 @@ BOOL CFamiTrackerDoc::OnSaveDocument(LPCTSTR lpszPathName)
 	// TODO: Dn-FamiTracker compatibility modes
 
 	// to avoid conflicts with FamiTracker beta 0.5.0 modules, set as Dn-FT module
-	if (m_iFileVersion >= 0x450U)
-		m_bFileDnModule = true;
+	m_bFileDnModule = true;
 	if (!SaveDocument(lpszPathName))
 		return FALSE;
 
@@ -816,7 +815,7 @@ bool CFamiTrackerDoc::WriteBlocks(CDocumentFile *pDocFile) const
 		// internal
 		6,		// Parameters
 		1,		// Song Info
-		1,		// Tuning
+		0,		// Tuning
 		3,		// Header
 		6,		// Instruments
 		6,		// Sequences
@@ -827,6 +826,7 @@ bool CFamiTrackerDoc::WriteBlocks(CDocumentFile *pDocFile) const
 #else
 		6,		// Parameters
 		1,		// Song Info
+		0,		// Tuning
 		3,		// Header
 		6,		// Instruments
 		6,		// Sequences
@@ -872,8 +872,9 @@ bool CFamiTrackerDoc::WriteBlocks(CDocumentFile *pDocFile) const
 	};
 
 	for (size_t i = 0; i < sizeof(FTM_WRITE_FUNC) / sizeof(*FTM_WRITE_FUNC); ++i) {
-		if (!CALL_MEMBER_FN(this, FTM_WRITE_FUNC[i])(pDocFile, DEFAULT_BLOCK_VERSION[i]))
-			return false;
+		if (DEFAULT_BLOCK_VERSION[i] != 0)		// !! !! check if block version is nonzero
+			if (!CALL_MEMBER_FN(this, FTM_WRITE_FUNC[i])(pDocFile, DEFAULT_BLOCK_VERSION[i]))
+				return false;
 	}
 	return true;
 }

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -2973,9 +2973,6 @@ bool CFamiTrackerView::EditEffNumberColumn(stChanNote &Note, Input input, int Ef
 				bStepDown = true;
 			return true;
 		}
-
-		if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
-			key = '0' + (key - VK_NUMPAD0);
 	}
 
 	CFamiTrackerDoc* pDoc = GetDocument();
@@ -2990,6 +2987,10 @@ bool CFamiTrackerView::EditEffNumberColumn(stChanNote &Note, Input input, int Ef
 
 	if (auto p = get_if<Keycode>(&input)) {
 		auto key = *p;
+
+		if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
+			key = '0' + (key - VK_NUMPAD0);
+
 		if (!isAlphanumeric(key)) {
 			return false;
 		}

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -1778,21 +1778,21 @@ void CFamiTrackerView::MoveCursorPrevChannel()
 
 void CFamiTrackerView::SelectFrame(unsigned int Frame)
 {
-	ASSERT(Frame < MAX_FRAMES);
+	ASSERT(static_cast<int>(Frame) < MAX_FRAMES);		// avoid comparing against UINT32_MAX
 	m_pPatternEditor->MoveToFrame(Frame);
 	InvalidateCursor();
 }
 
 void CFamiTrackerView::SelectRow(unsigned int Row)
 {
-	ASSERT(Row < MAX_PATTERN_LENGTH);
+	ASSERT(static_cast<int>(Row) < MAX_PATTERN_LENGTH);		// avoid comparing against UINT32_MAX
 	m_pPatternEditor->MoveToRow(Row);
 	InvalidateCursor();
 }
 
 void CFamiTrackerView::SelectChannel(unsigned int Channel)
 {
-	ASSERT(Channel < MAX_CHANNELS);
+	ASSERT(static_cast<int>(Channel) < MAX_CHANNELS);		// avoid comparing against UINT32_MAX
 	m_pPatternEditor->MoveToChannel(Channel);
 	InvalidateCursor();
 }

--- a/Source/FrameAction.cpp
+++ b/Source/FrameAction.cpp
@@ -34,7 +34,7 @@
 
 CFrameEditorState::CFrameEditorState(const CFamiTrackerView *pView, int Track) :		// // //
 	Track(Track),
-	Cursor {static_cast<CMainFrame*>(pView->GetParentFrame())->GetFrameEditor()->GetEditFrame(), (int)pView->GetSelectedChannel()},
+	Cursor{ static_cast<CMainFrame*>(pView->GetParentFrame())->GetFrameEditor()->GetEditFrame(), static_cast<int>(pView->GetSelectedChannel()) },
 	OriginalSelection(static_cast<CMainFrame*>(pView->GetParentFrame())->GetFrameEditor()->GetSelection()),
 	IsSelecting(static_cast<CMainFrame*>(pView->GetParentFrame())->GetFrameEditor()->IsSelecting())
 {

--- a/Source/SequenceParser.cpp
+++ b/Source/SequenceParser.cpp
@@ -65,7 +65,7 @@ bool CSeqConversionDefault::ToValue(const std::string &String)
 		if (!GetNextInteger(b, e, m_iRepeat))
 			return false;
 	}
-	if (b != e || m_iRepeat <= 0)
+	if (b != e || m_iRepeat <= 0 || m_iValueDiv <= 0)
 		return false;
 	m_iValueInc = m_iTargetValue - m_iCurrentValue;
 	m_iRepeatCounter = m_iCounter = m_iValueMod = 0;

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -456,7 +456,7 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 		// // // VRC7
 		if (i < NOTE_RANGE) {
 			Pitch = pDetuneVRC7->FrequencyToPeriod(pDetuneVRC7->NoteToFreq(i), 1, 0);
-			m_iNoteLookupTableVRC7[i] = std::lround(Pitch - pDocument->GetDetuneOffset(3, i));		// // //
+			m_iNoteLookupTableVRC7[i] = std::lround(Pitch + pDocument->GetDetuneOffset(3, i));		// // //
 		}
 
 		// FDS
@@ -465,11 +465,11 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 #else
 		Pitch = (NoteToFreq(i) * 65536.0) / (clock_ntsc / 4.0);
 #endif
-		m_iNoteLookupTableFDS[i] = std::lround(Pitch - pDocument->GetDetuneOffset(4, i));		// // //
+		m_iNoteLookupTableFDS[i] = std::lround(Pitch + pDocument->GetDetuneOffset(4, i));		// // //
 
 		// N163
 		Pitch = pDetuneN163->FrequencyToPeriod(pDetuneN163->NoteToFreq(i), 1, pDocument->GetNamcoChannels());
-		m_iNoteLookupTableN163[i] = std::lround(Pitch - pDocument->GetDetuneOffset(5, i));		// // //
+		m_iNoteLookupTableN163[i] = std::lround(Pitch + pDocument->GetDetuneOffset(5, i));		// // //
 
 		if (m_iNoteLookupTableN163[i] > 0xFFFF)	// 0x3FFFF
 			m_iNoteLookupTableN163[i] = 0xFFFF;	// 0x3FFFF

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -2407,7 +2407,7 @@ void CSoundGen::UpdateAPU()
 	m_bInternalWaveChanged = m_bWaveChanged;
 	m_bWaveChanged = false;
 
-	auto UpdateAPU = [&]() {
+	auto UpdateAPUImpl = [&]() {
 		unsigned int PrevChip = SNDCHIP_NONE;		// // // 050B
 		for (int i = 0; i < CHANNELS; ++i) {
 			if (m_pChannels[i] != NULL) {
@@ -2441,13 +2441,13 @@ void CSoundGen::UpdateAPU()
 	{
 		if (m_bRendering) {
 			auto l = Lock();
-			UpdateAPU();
+			UpdateAPUImpl();
 			l.unlock();
 		}
 		else {
 			auto l = DeferLock();
 			if (l.try_lock()) {
-				UpdateAPU();
+				UpdateAPUImpl();
 				l.unlock();
 			}
 			else TRACE("SoundGen: APU mutex lock failed\n");

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -2450,7 +2450,7 @@ void CSoundGen::UpdateAPU()
 				UpdateAPU();
 				l.unlock();
 			}
-			else TRACE("SoundGen: APU mutex lock failed");
+			else TRACE("SoundGen: APU mutex lock failed\n");
 		}
 	}
 

--- a/Source/TextExporter.cpp
+++ b/Source/TextExporter.cpp
@@ -1743,16 +1743,18 @@ const CString& CTextExport::ExportFile(LPCTSTR FileName, CFamiTrackerDoc *pDoc)
 	f.WriteString(_T("# JSON block\n"));
 	{
 		json j = pDoc->InterfaceToOptionalJSON();
-		std::string &jsondump = j.dump(4, ' ', true);
-		std::string &delimiter = std::string("\n");
-		std::string::size_type pos = 0, prev = 0;
-		while ((pos = jsondump.find(delimiter, prev)) != std::string::npos) {
-			s.Format(_T("%s %s\n"), CT[CT_JSON], ExportString(jsondump.substr(prev, pos - prev).c_str()));
+		if (!j.is_null()) {
+			std::string& jsondump = j.dump(4, ' ', true);
+			std::string& delimiter = std::string("\n");
+			std::string::size_type pos = 0, prev = 0;
+			while ((pos = jsondump.find(delimiter, prev)) != std::string::npos) {
+				s.Format(_T("%s %s\n"), CT[CT_JSON], ExportString(jsondump.substr(prev, pos - prev).c_str()));
+				f.WriteString(s);
+				prev = pos + delimiter.size();
+			}
+			s.Format(_T("%s %s\n"), CT[CT_JSON], ExportString(jsondump.substr(prev).c_str()));
 			f.WriteString(s);
-			prev = pos + delimiter.size();
 		}
-		s.Format(_T("%s %s\n"), CT[CT_JSON], ExportString(jsondump.substr(prev).c_str()));
-		f.WriteString(s);
 	}
 	f.WriteString(_T("\n"));
 


### PR DESCRIPTION
This pull request aims to fix module state and interaction bugs.

This pull request iterates upon PR #195.

### Changes in this PR:
 - Avoid checking pattern editor assert with unsigned integer cast
   - Fixes #209.
 - Wait for APU mutex lock during .wav export
   - Fixes #206.
 - Assert legacy mixing levels and ranges
   - Fixes #213.
 - Fix detune offset direction
   - Fixes #225.
  - Fix incorrect speed in PAL NSF exports
    - Fixes #223.
  - Fix access violation in MRU submenu list update
    - Fixes #243.
  - Avoid division by zero in MML sequence parsing
    - Fixes #222.
  - Fix effect number input using numpad
    - Fixes #48.
  - Disable Custom Exporter DLL loading
    - Fixes #232.
  - Force modules to be saved as Dn-FT modules
    - This prevents modules to be saved with version 0x450 but without the Dn-FT specific file header, causing the program to interpret it as FT 050b modules instead.
    - Fixes complications from fixing #184.
