### PR TITLE
Fix outputting audio to multi-channel output devices

### DIFF
--- a/Source/SoundInterface.cpp
+++ b/Source/SoundInterface.cpp
@@ -31,7 +31,6 @@
 #include <utility>  // std::move
 #include "Common.h"
 #include "SoundInterface.h"
-#include <stdexcept>
 #include "../resource.h"
 
 // WASAPI headers
@@ -247,7 +246,9 @@ CSoundStream *CSoundInterface::OpenFloatChannel(const int InputChannels, int Buf
 		// outputs a pointer to the WAVEFORMATEX structure that is embedded at the
 		// start of this WAVEFORMATEXTENSIBLE structure."
 		if (pMixFormat->wFormatTag != WAVE_FORMAT_EXTENSIBLE) {
-			throw std::runtime_error("GetMixFormat() wFormatTag not WAVE_FORMAT_EXTENSIBLE!");
+			TRACE("GetMixFormat() wFormatTag=%x not WAVE_FORMAT_EXTENSIBLE!", pMixFormat->wFormatTag);
+			CoTaskMemFree(pMixFormat);
+			return nullptr;
 		}
 		ASSERT(pMixFormat->cbSize >= 22);
 		auto mixFormatExt = (WAVEFORMATEXTENSIBLE*)pMixFormat;

--- a/Source/utils/handle_ptr.h
+++ b/Source/utils/handle_ptr.h
@@ -13,3 +13,5 @@ struct CloseHandleT {
 
 /// HANDLE is void*, so unique_ptr<void, CloseHandleT> is a RAII HANDLE.
 using HandlePtr = std::unique_ptr<void, CloseHandleT>;
+// https://learn.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-createeventa
+// >If the function fails, the return value is NULL.


### PR DESCRIPTION
This pull request aims to add support for multi-channel audio devices which would previously fail to open.

Tested to play audio properly on Windows 11 with mono, stereo, and surround audio devices (outputs to first 2 channels). Tested to play sound on stereo speakers on Wine on PipeWire.

### Changes in this PR:
 - Fix outputting audio to multi-channel output devices
   - Fixes issue #205.