### PR TITLE
Properly associate .dnm files to open in Dn-FamiTracker

### DIFF
--- a/Dn-FamiTracker.rc
+++ b/Dn-FamiTracker.rc
@@ -2551,7 +2551,7 @@ IDR_HTML1               HTML                    "res/export_report.htm"
 
 STRINGTABLE
 BEGIN
-    IDR_MAINFRAME           "Dn-FamiTracker\n\nDn-FamiTracker\nDn-FamiTracker modules (*.0cc;*.ftm)\n.0cc\n0CCFamiTracker.Document\n0CCFamiTracker.Document"
+    IDR_MAINFRAME           "Dn-FamiTracker\n\nDn-FamiTracker\nDn-FamiTracker modules (*.dnm;*.0cc;*.ftm)\n.dnm\nDnFamiTracker.Document\nDn-FamiTracker Document"
     IDS_FRAME_DROP_MOVE     "Drop selection to move frames"
     IDS_DPCM_IMPORT_QUALITY_FORMAT "Quality: %1"
     IDS_CLIPBOARD_ERROR     "Could not register clipboard format"

--- a/Source/FamiTracker.cpp
+++ b/Source/FamiTracker.cpp
@@ -184,6 +184,10 @@ BOOL CFamiTrackerApp::InitInstance()
 
 	// Register the application's document templates.  Document templates
 	//  serve as the connection between documents, frame windows and views
+
+	// The IDR_MAINFRAME string is used to create file associations with .dnm files.
+	// See https://learn.microsoft.com/en-us/cpp/mfc/reference/cdoctemplate-class?view=msvc-170#getdocstring
+	// for the format of this string.
 	CDocTemplate0CC* pDocTemplate = new CDocTemplate0CC(		// // //
 		IDR_MAINFRAME,
 		RUNTIME_CLASS(CFamiTrackerDoc),
@@ -208,7 +212,7 @@ BOOL CFamiTrackerApp::InitInstance()
 	// Add shell options
 	RegisterShellFileTypes();		// // //
 	static const LPCTSTR FILE_ASSOC_NAME = _T(APP_NAME " Module");
-	AfxRegSetValue(HKEY_CLASSES_ROOT, "0CCFamiTracker.Document", REG_SZ, FILE_ASSOC_NAME, lstrlen(FILE_ASSOC_NAME) * sizeof(TCHAR));
+	AfxRegSetValue(HKEY_CLASSES_ROOT, "DnFamiTracker.Document", REG_SZ, FILE_ASSOC_NAME, lstrlen(FILE_ASSOC_NAME) * sizeof(TCHAR));
 	// Add an option to play files
 	CString strPathName, strTemp, strFileTypeId;
 	AfxGetModuleShortFileName(AfxGetInstanceHandle(), strPathName);


### PR DESCRIPTION
This pull request aims to make release builds properly associate .dnm files to open in Dn-FamiTracker. Previously saving a .dnm file would not allow you to open it from Explorer.

Note that this only works (and was tested months ago lmao) with `#define WIP` removed.

### Changes in this PR:
- Properly associate .dnm files to open in Dn-FamiTracker, rather than .0cc files.