### PR TITLE
Fix data race UB (audio thread pushing to its own message queue) triggered by WAV export

### DIFF
--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -40,6 +40,7 @@
 #include <atomic>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <thread>
 
 const int VIBRATO_LENGTH = 256;
@@ -139,6 +140,11 @@ public:
 
 private:
 	void ThreadEntry();
+
+	bool PostSelfMessage(
+		GuiMessageId message,
+		WPARAM wParam,
+		LPARAM lParam);
 
 public:
 	bool PostGuiMessage(
@@ -339,6 +345,7 @@ public:
 	// Accessed by CCompiler for mixe chunk
 	std::vector<int16_t> SurveyMixLevels;
 private:
+	std::optional<GuiMessage> m_maybeSelfMessage;
 	rigtorp::SPSCQueue<GuiMessage> m_MessageQueue;
 
 	// Objects


### PR DESCRIPTION
In a previous PR #137, I replaced audio thread communication with inter-thread message queues to prevent blocking the audio thread and interrupting playback. Unfortunately I missed a case where when you perform WAV export, the *audio thread* itself is pushing into the message queue intended for GUI-to-audio commands. This results in a UB data race on the lock-free ring buffer queue, which could result in missing or invalid commands being processed.

Separately I've noticed crashes upon WAV export where `m_bRendering` is true, but `m_pWaveFile` is null while calling `m_pWaveFile->WriteWave()`. I don't know how it happens, but it may be related to the above UB.

I'm fixing the data race by introducing a separate object for messages sent from the audio thread to itself. Hopefully it fixes the WAV export crash, but it's intermittent and I can't reproduce it on demand on the old code, nor prove that this change fixes it.

### Changes in this PR:
 - Fix data race UB (audio thread pushing to its own message queue) triggered by WAV export
