### PR TITLE
Fix misaligned instrument editor graph/mouse at high DPI

### DIFF
--- a/Source/GraphEditor.h
+++ b/Source/GraphEditor.h
@@ -78,6 +78,8 @@ protected:
 	static const int ITEM_MAX_WIDTH = 40;
 	static const int COLOR_LINES = 0x404040;
 
+	int m_graphLeft;
+
 protected:
 	CWnd *m_pParentWnd;
 	CSequence *const m_pSequence;


### PR DESCRIPTION
This pull request aims to fix the bug where the instrument editor graph's click target doesn't line up with the mouse position at high Windows DPI.

This does not fix the text and piano being shrunken at high DPI, nor skipping points when dragging the mouse quickly (could be cherry-picked from 0CC?).

### Changes in this PR:
 - Fix misaligned instrument editor graph/mouse at high DPI
