### PR TITLE
Grey out record instrument option on invalid parts of header

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -702,13 +702,14 @@ void CFamiTrackerView::OnRButtonUp(UINT nFlags, CPoint point)
 	GetWindowRect(WinRect);
 
 	if (m_pPatternEditor->IsOverHeader(point)) {
+		int ChannelCount = GetDocument()->GetAvailableChannels();
 		// Pattern header
 		m_iMenuChannel = m_pPatternEditor->GetChannelAtPoint(point.x);
 		PopupMenuBar.LoadMenu(IDR_PATTERN_HEADER_POPUP);
 		static_cast<CMainFrame*>(theApp.GetMainWnd())->UpdateMenu(&PopupMenuBar);
 		pPopupMenu = PopupMenuBar.GetSubMenu(0);
-		pPopupMenu->EnableMenuItem(ID_TRACKER_RECORDTOINST, theApp.IsPlaying() ? MF_DISABLED : MF_ENABLED);		// // //
-		pPopupMenu->EnableMenuItem(ID_TRACKER_RECORDERSETTINGS, theApp.IsPlaying() ? MF_DISABLED : MF_ENABLED);		// // //
+		pPopupMenu->EnableMenuItem(ID_TRACKER_RECORDTOINST, (theApp.IsPlaying() || m_iMenuChannel >= ChannelCount) ? MF_DISABLED : MF_ENABLED);		// // //
+		pPopupMenu->EnableMenuItem(ID_TRACKER_RECORDERSETTINGS, (theApp.IsPlaying() || m_iMenuChannel >= ChannelCount) ? MF_DISABLED : MF_ENABLED);		// // //
 		CMenu *pMeterMenu = pPopupMenu->GetSubMenu(6);		// // // 050B
 		int Rate = theApp.GetSoundGenerator()->GetMeterDecayRate();
 		pMeterMenu->CheckMenuItem(Rate == DECAY_FAST ? ID_DECAY_FAST : ID_DECAY_SLOW, MF_CHECKED | MF_BYCOMMAND);


### PR DESCRIPTION
This PR addresses #279, disallowing selecting the context menu option to record to instrument when not clicking on a channel header.

![image](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/assets/31630195/38030d9b-e836-42d4-9a5f-679f76fb7082)
![image](https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/assets/31630195/432cd991-45ab-427a-92c5-615f714a5c08)