### PR TITLE
Fix double-free in drag and drop

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -4126,6 +4126,7 @@ void CFamiTrackerView::BeginDragData(int ChanOffset, int RowOffset)
 		m_bDragSource = true;
 		m_bDropped = false;
 
+		// move hMem
 		pSrc->CacheGlobalData(mClipboardFormat, hMem);
 		DROPEFFECT res = pSrc->DoDragDrop(DROPEFFECT_COPY | DROPEFFECT_MOVE);
 
@@ -4144,7 +4145,7 @@ void CFamiTrackerView::BeginDragData(int ChanOffset, int RowOffset)
 
 	m_bDragSource = false;
 
-	::GlobalFree(hMem);
+	// ~pSrc() calls GlobalFree on hMem.
 }
 
 bool CFamiTrackerView::IsDragging() const


### PR DESCRIPTION
This pull request aims to fix a double-free error caught by ASan.

- In function `CFamiTrackerView::BeginDragData()`, we allocate `HGLOBAL hMem = ::GlobalAlloc(GMEM_MOVEABLE, Size)`, and pass to `pSrc->CacheGlobalData(mClipboardFormat, hMem)`.
	- `std::shared_ptr<COleDataSource> pSrc` takes ownership of the handle and stores it in `pEntry->m_stgMedium.hGlobal = hGlobal`.
- Before `BeginDragData` returns, we explicitly call `::GlobalFree(hMem)`.
- `BeginDragData` returns and destroys `shared_ptr<COleDataSource> pSrc`.
	- `~COleDataSource() → COleDataSource::Empty()` calls `::ReleaseStgMedium(&m_pDataCache[nIndex].m_stgMedium)` which frees `m_stgMedium.hGlobal` again. This is a double-free bug.

The solution is to remove the redundant incorrect `GlobalFree` call, and let `COleDataSource` destroy the handle.

I don't know what any of this OLE code does lol.

### Changes in this PR:
- Fix a memory double-free that occurs when drag-dropping on the tracker view.
	- It did not appear to previously cause stability issues; perhaps the GlobalAlloc/Free functions ignore double-frees
	- Fixes issue #295.