### PR TITLE
Fix overlapping memcpy bug in DPCM sample editor

### DIFF
--- a/Source/SampleEditorDlg.cpp
+++ b/Source/SampleEditorDlg.cpp
@@ -194,7 +194,7 @@ void CSampleEditorDlg::OnBnClickedDelete()
 	TRACE(_T("Removing selected part from sample, start: %i, end %i (diff: %i)\n"), StartSample, EndSample, EndSample - StartSample);
 
 	// Remove the selected part
-	memcpy(m_pSample->GetData() + StartSample, m_pSample->GetData() + EndSample, m_pSample->GetSize() - EndSample);
+	memmove(m_pSample->GetData() + StartSample, m_pSample->GetData() + EndSample, m_pSample->GetSize() - EndSample);
 	int NewSize = m_pSample->GetSize() - (EndSample - StartSample);
 
 	// Reallocate


### PR DESCRIPTION
Does Windows actually implement memcpy and memmove differently?

This pull request aims to remove undefined behavior from calling memcpy on overlapping memory. (I don't know if MSVC actually distinguishes these functions.)

(If applicable) This pull request improves upon and supercedes `#<PR number>`.

### Changes in this PR:

- (cite all changes made in the PR for change log)
	- Fixes/addresses issue `#<issue number>`.
