### PR TITLE
Fix WAV export crash caused by uninitialized variables

### DIFF
--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -154,6 +154,7 @@ public:
 		_generation++;
 
 		log_("dump()");
+		lock.unlock();
 		MessageBoxA(nullptr,
 			"WAV export error, please report and attach wavlog-*.txt",
 			"WAV export error",

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -251,6 +251,10 @@ CSoundGen::CSoundGen() :
 	m_iMachineType(NTSC),
 	m_bRequestRenderStart(false),
 	m_bRendering(false),
+	m_bRequestRenderStop(false),
+	m_bStoppingRender(false),
+	m_iDelayedStart(0),
+	m_iDelayedEnd(0),
 	m_iBPMCachePosition(0),
 	m_iRegisterStream(),
 	m_bWaveChanged(0),		// // //


### PR DESCRIPTION
This pull request aims to fix random crashes the first time you export a WAV file from FamiTracker.

`bool CSoundGen::m_bStoppingRender` failed to be initialized. If it happened to be nonzero, `(audio) CSoundGen::OnIdle()` would count down `m_iDelayedEnd` to 0 and then call `StopRendering()` on every frame, which would fail because `IsRendering()` is false. (This error was silent on release builds before #353, but now dumps a log and blocks the audio thread with a dialog.)

The crash happens when the user initiates a render on the GUI thread (setting `m_pWaveFile` and `m_bRequestRenderStart`). While the audio thread is looping, `OnIdle() → StopRendering()` could succeed and erase `m_pWaveFile` before `(audio) CSoundGen::DispatchGuiMessage()` processes `WM_USER_START_RENDER` from the GUI. Attempting to render without `m_pWaveFile` would crash.

Fix this by initializing `CSoundGen::m_bStoppingRender`, as well as other flags that the code doesn't access immediately but I don't want to leave uninitialized. I didn't initialize everything because I don't understand the existing code.

Crash log:

```
(audio)
(m_bStoppingRender) { CSoundGen::StopRendering
    ASSERT(m_bRendering) failed
} !IsRendering(), CSoundGen::StopRendering
repeats...

(m_bStoppingRender) { CSoundGen::StopRendering
    ASSERT(m_bRendering) failed
    ...

(gui)
{ CSoundGen::RenderToFile
    m_pWaveFile = std::make_unique<CWaveFile>();
    m_bRequestRenderStart = true;
    CSoundGen::GuiPostMessage(WM_USER_START_RENDER)
} CSoundGen::RenderToFile

(audio)
    m_pWaveFile.reset();
} CSoundGen::StopRendering
(WM_USER_START_RENDER:)
{ CSoundGen::OnStartRender
    {} Lock()
    m_bRendering = true;
} CSoundGen::OnStartRender
{ CSoundGen::FillBuffer
    if (m_bRendering) {
        ASSERT(m_pWaveFile) failed
        (crash)
```

_This pull request improves upon and supercedes #272._

----

Also update the logging infrastructure to "Don't hold mutex during WAV export error dialog".

- [x] Do we keep the WAV logging infrastructure indefinitely, or remove it once people stop hitting crashes in the wild?

### Changes in this PR:

- Fix WAV export crash caused by uninitialized variables.
	- Fixes #190?
	- See #159.
