### PR TITLE
fix: add offsets to auto scroll row values to prevent scrolling when reaching first and last row

### DIFF
--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -452,7 +452,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
-      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/FS /utf-8 %(AdditionalOptions)</AdditionalOptions>
       <OmitFramePointers>false</OmitFramePointers>
     </ClCompile>
     <ResourceCompile>

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -3937,7 +3937,7 @@ void CPatternEditor::AutoScroll(const CPoint &point, UINT nFlags)
 
 	int Row = (point.y - HEADER_HEIGHT) / m_iRowHeight - (m_iLinesVisible / 2);		// // //
 
-	if (Row > (m_iLinesFullVisible / 2) - 0) {
+	if (Row > (m_iLinesFullVisible / 2) + 1) {
 		m_iScrolling |= SCROLL_DOWN;		// // //
 	}
 	else if (Row <= -(m_iLinesFullVisible / 2) - 1) {

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -3937,7 +3937,7 @@ void CPatternEditor::AutoScroll(const CPoint &point, UINT nFlags)
 
 	int Row = (point.y - HEADER_HEIGHT) / m_iRowHeight - (m_iLinesVisible / 2);		// // //
 
-	if (Row > (m_iLinesFullVisible / 2) - 3) {
+	if (Row > (m_iLinesFullVisible / 2) - 0) {
 		m_iScrolling |= SCROLL_DOWN;		// // //
 	}
 	else if (Row <= -(m_iLinesFullVisible / 2) - 1) {

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -3940,7 +3940,7 @@ void CPatternEditor::AutoScroll(const CPoint &point, UINT nFlags)
 	if (Row > (m_iLinesFullVisible / 2) - 3) {
 		m_iScrolling |= SCROLL_DOWN;		// // //
 	}
-	else if (Row <= -(m_iLinesFullVisible / 2)) {
+	else if (Row <= -(m_iLinesFullVisible / 2) - 1) {
 		m_iScrolling |= SCROLL_UP;		// // //
 	}
 


### PR DESCRIPTION
This pull request aims to change auto scroll to not scroll when dragging to row 0 and the last row to make row 0 and the last row selectable. This is done by adding a -1 offset to the auto scroll row value for `SCROLL_UP` and adding a +1 offset to to the auto scroll row value for `SCROLL_DOWN`.

Right now this happens:
![mousecausesscroll](https://github.com/user-attachments/assets/73d9f556-76b8-45bd-ab8f-987389ce657a)

After this PR:
![mousecausesscrollfixed](https://github.com/user-attachments/assets/154afab5-1812-4927-b60a-ce61ce351ede)

It is still possible to scroll to the previous rows but only above row 0 which makes row 0 actually selectable. The same is true for the last row.

This PR also adds `/utf-8` in the build additional options to make building possible on Windows computers with Japanese system codes.

fixes https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/issues/351

### Changes in this PR:

- (cite all changes made in the PR for change log)
	- Pattern editor auto scroll offsets were changed to allow for selecting the first/last rows without scrolling (https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/issues/351)
	- Adds `/utf-8` to build additional options to make building possible on Windows computers with Japanese system codes
