### PR TITLE
Bypassing chip-global effects even if the channel is muted

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -1582,9 +1582,9 @@ bool CFamiTrackerView::PlayerGetNote(int Track, int Frame, int Channel, int Row,
 	}
 	else {
 		// These effects will pass even if the channel is muted
-		const int PASS_EFFECTS[] = {EF_HALT, EF_JUMP, EF_SPEED, EF_SKIP, EF_GROOVE, \
-			EF_VRC7_PORT, EF_VRC7_WRITE, 
-			EF_N163_WAVE_BUFFER, 
+		const int PASS_EFFECTS[] = {EF_HALT, EF_JUMP, EF_SPEED, EF_SKIP, EF_GROOVE,
+			EF_VRC7_PORT, EF_VRC7_WRITE,
+			EF_N163_WAVE_BUFFER,
 			EF_SUNSOFT_ENV_HI, EF_SUNSOFT_ENV_LO, EF_SUNSOFT_ENV_TYPE, EF_SUNSOFT_NOISE
 		};		// // //
 		int Columns = pDoc->GetEffColumns(Track, Channel) + 1;

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -1582,7 +1582,11 @@ bool CFamiTrackerView::PlayerGetNote(int Track, int Frame, int Channel, int Row,
 	}
 	else {
 		// These effects will pass even if the channel is muted
-		const int PASS_EFFECTS[] = {EF_HALT, EF_JUMP, EF_SPEED, EF_SKIP, EF_GROOVE};		// // //
+		const int PASS_EFFECTS[] = {EF_HALT, EF_JUMP, EF_SPEED, EF_SKIP, EF_GROOVE, \
+			EF_VRC7_PORT, EF_VRC7_WRITE, 
+			EF_N163_WAVE_BUFFER, 
+			EF_SUNSOFT_ENV_HI, EF_SUNSOFT_ENV_LO, EF_SUNSOFT_ENV_TYPE, EF_SUNSOFT_NOISE
+		};		// // //
 		int Columns = pDoc->GetEffColumns(Track, Channel) + 1;
 
 		NoteData.Note		= HALT;


### PR DESCRIPTION
This PR aims to add some of chip-global effects on PASS_EFFECTS[], which makes the seperated channel output(s) more consistently, and fixes the seperated channel output(s) outputting unintented sounds.

By adding `EF_VRC7_PORT, EF_VRC7_WRITE, EF_N163_WAVE_BUFFER, EF_SUNSOFT_ENV_HI, EF_SUNSOFT_ENV_LO, EF_SUNSOFT_ENV_TYPE, EF_SUNSOFT_NOISE`

### Changes in this PR :

- (cite all changes made in the PR for change log)
	- Add `Hxy` `Ixy` `Jxy` (for both VRC7, 5B) and `Zxy` (for N163) effects on `PASS_EFFECTS[]`
