### PR TITLE
fix: correctly reset tempo on frame change when retrieve channel state setting is used

### DIFF
--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -1858,17 +1858,39 @@ void CSoundGen::ResetTempo()
 
 	m_iTempoAccum = 0;
 
-	if (m_pDocument->GetSongGroove(m_iPlayTrack) && m_pDocument->GetGroove(m_iSpeed) != NULL) {		// // //
-		m_iGrooveIndex = m_iSpeed;
-		m_iGroovePosition = 0;
-		if (m_pDocument->GetGroove(m_iGrooveIndex) != NULL)
-			m_iSpeed = m_pDocument->GetGroove(m_iGrooveIndex)->GetEntry(m_iGroovePosition);
-	}
-	else {
-		m_iGrooveIndex = -1;
-		if (m_pDocument->GetSongGroove(m_iPlayTrack))
-			m_iSpeed = DEFAULT_SPEED;
-	}
+  if (theApp.GetSettings()->General.bRetrieveChanState)	{
+    int Frame = IsPlaying() ? GetPlayerFrame() : m_pTrackerView->GetSelectedFrame();
+	  int Row = IsPlaying() ? GetPlayerRow() : m_pTrackerView->GetSelectedRow();
+    if (stFullState *State = m_pDocument->RetrieveSoundState(GetPlayerTrack(), Frame, Row, -1)) {
+		if (State->Tempo != -1)
+			m_iTempo = State->Tempo;
+		if (State->GroovePos >= 0) {
+			m_iGroovePosition = State->GroovePos;
+			if (State->Speed >= 0)
+				m_iGrooveIndex = State->Speed;
+			if (m_pDocument->GetGroove(m_iGrooveIndex) != NULL)
+				m_iSpeed = m_pDocument->GetGroove(m_iGrooveIndex)->GetEntry(m_iGroovePosition);
+		}
+		else {
+			if (State->Speed >= 0)
+				m_iSpeed = State->Speed;
+			m_iGrooveIndex = -1;
+		  }
+    }
+  }
+  else {
+    if (m_pDocument->GetSongGroove(m_iPlayTrack) && m_pDocument->GetGroove(m_iSpeed) != NULL) {		// // //
+        m_iGrooveIndex = m_iSpeed;
+        m_iGroovePosition = 0;
+      if (m_pDocument->GetGroove(m_iGrooveIndex) != NULL)
+        m_iSpeed = m_pDocument->GetGroove(m_iGrooveIndex)->GetEntry(m_iGroovePosition);
+    }
+    else {
+      m_iGrooveIndex = -1;
+      if (m_pDocument->GetSongGroove(m_iPlayTrack))
+        m_iSpeed = DEFAULT_SPEED;
+    }
+  }
 	SetupSpeed();
 
 	m_bUpdateRow = false;

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -1858,40 +1858,23 @@ void CSoundGen::ResetTempo()
 
 	m_iTempoAccum = 0;
 
-  if (theApp.GetSettings()->General.bRetrieveChanState)	{
-    int Frame = IsPlaying() ? GetPlayerFrame() : m_pTrackerView->GetSelectedFrame();
-	  int Row = IsPlaying() ? GetPlayerRow() : m_pTrackerView->GetSelectedRow();
-    if (stFullState *State = m_pDocument->RetrieveSoundState(GetPlayerTrack(), Frame, Row, -1)) {
-		if (State->Tempo != -1)
-			m_iTempo = State->Tempo;
-		if (State->GroovePos >= 0) {
-			m_iGroovePosition = State->GroovePos;
-			if (State->Speed >= 0)
-				m_iGrooveIndex = State->Speed;
+	if (theApp.GetSettings()->General.bRetrieveChanState)		// // // 
+		ApplyGlobalState();
+	// Legacy behavior
+	else {
+		if (m_pDocument->GetSongGroove(m_iPlayTrack) && m_pDocument->GetGroove(m_iSpeed) != NULL) {		// // //
+			m_iGrooveIndex = m_iSpeed;
+			m_iGroovePosition = 0;
 			if (m_pDocument->GetGroove(m_iGrooveIndex) != NULL)
 				m_iSpeed = m_pDocument->GetGroove(m_iGrooveIndex)->GetEntry(m_iGroovePosition);
 		}
 		else {
-			if (State->Speed >= 0)
-				m_iSpeed = State->Speed;
 			m_iGrooveIndex = -1;
-		  }
-    }
-  }
-  else {
-    if (m_pDocument->GetSongGroove(m_iPlayTrack) && m_pDocument->GetGroove(m_iSpeed) != NULL) {		// // //
-        m_iGrooveIndex = m_iSpeed;
-        m_iGroovePosition = 0;
-      if (m_pDocument->GetGroove(m_iGrooveIndex) != NULL)
-        m_iSpeed = m_pDocument->GetGroove(m_iGrooveIndex)->GetEntry(m_iGroovePosition);
-    }
-    else {
-      m_iGrooveIndex = -1;
-      if (m_pDocument->GetSongGroove(m_iPlayTrack))
-        m_iSpeed = DEFAULT_SPEED;
-    }
-  }
-	SetupSpeed();
+			if (m_pDocument->GetSongGroove(m_iPlayTrack))
+				m_iSpeed = DEFAULT_SPEED;
+		}
+		SetupSpeed();
+	}
 
 	m_bUpdateRow = false;
 }


### PR DESCRIPTION
This pull request aims to correctly reset the tempo on frame change when the retrieve channel state setting is used.
Eg. right now if you have a groove `Oxx` or `Fxx` in only the first pattern and change the frame while playing back, the tempo is reset using the default speed/tempo instead of the retrieved groove/speed settings. This PR changes this to correctly reset the tempo to the actual groove setting used so the tempo stays consistent even when changing frames during playback.

It looks like there was some groove/speed handling in there already (which didn't work using retrieve channel state) so I split that code with an if/else depending on `General.bRetrieveChanState` and took the working code from `CSoundGen::ApplyGlobalState()`. Maybe there's a smarter way to fix this, if that's the case feel free to edit. 

fixes https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/issues/357

### Changes in this PR:

- (cite all changes made in the PR for change log)
	- Correctly reset tempo on frame change when retrieve channel state setting is used (fixes https://github.com/Dn-Programming-Core-Management/Dn-FamiTracker/issues/357)
