### PR TITLE
Update Windows SDK version to `10.0.26100`

### DIFF
--- a/Dn-FamiTracker.vcxproj
+++ b/Dn-FamiTracker.vcxproj
@@ -40,7 +40,7 @@
     <Keyword>MFCProj</Keyword>
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <ProjectName>Dn-FamiTracker</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.20348.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,8 +54,8 @@ To edit and/or build the source, you may use Visual Studio 2022, or alternativel
 	- CMake
 	- The latest MSVC build tools 
 		- may be installed by VS Installer or by other sources
-	- Windows 10 SDK version 2104 (10.0.20348.0)
-		- may be installed by VS Installer or by other sources
+	- Windows 11 SDK (10.0.26100.0)
+		- may be installed through VS Installer or by other sources
 	- These dependencies can be installed through the Visual Studio Installer:
 		- C++ MFC for latest v143 build tools (x86 & x64)
 		- C++ ATL for latest v143 build tools (x86 & x64)


### PR DESCRIPTION
This pull request aims to update the VS solution's Windows SDK version to `10.0.26100`.

### Changes in this PR:

- Update Windows SDK version to `10.0.26100`
	- This resolves #370.
- Update Windows SDK documentation in `CONTRIBUTING.md`