### PR TITLE
feat (pattern-editor): allow for copying single row in highlighted channel when no selection is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ Written by D.P.C.M.
 
 Version 0.5.3.9
 
-Last updated: 2026-05-30
+Last updated: 2026-05-31
 
 ---
 
-## Unreleased - 2026-05-30
+## Unreleased - 2026-05-31
 
 ### Breaking changes
 
@@ -22,6 +22,7 @@ Last updated: 2026-05-30
 
 ### Improvements
 
+- Allow copying entire channel row at cursor with no selection (@henrikvilhelmberglund #385)
 - Add color and font appearance setting for channel header (@Nemo55aa #413 #409)
 
 ### Bug fixes

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -2496,8 +2496,21 @@ void CMainFrame::OnUpdateEditCut(CCmdUI *pCmdUI)
 
 void CMainFrame::OnUpdateEditCopy(CCmdUI *pCmdUI)
 {
-	CFamiTrackerView *pView	= static_cast<CFamiTrackerView*>(GetActiveView());
-	pCmdUI->Enable((pView->IsSelecting() || GetFocus() == m_pFrameEditor) ? 1 : 0);
+  CFamiTrackerView *pView = static_cast<CFamiTrackerView*>(GetActiveView());
+  bool patternEditorFocused = (GetFocus() == pView);
+  bool hasSelection = pView->IsSelecting();
+
+  // Check if the cursor is on a valid cell in the pattern editor
+  bool cursorValid = false;
+  if (patternEditorFocused) {
+    auto *pEditor = pView->GetPatternEditor();
+    const auto &cursor = pEditor->GetCursor();
+    int frameLen = pEditor->GetCurrentPatternLength(cursor.m_iFrame);
+    int channelCount = static_cast<CFamiTrackerDoc*>(GetActiveDocument())->GetAvailableChannels();
+    cursorValid = cursor.IsValid(frameLen, channelCount);
+  }
+
+  pCmdUI->Enable(hasSelection || cursorValid);
 }
 
 void CMainFrame::OnUpdatePatternEditorSelected(CCmdUI *pCmdUI)		// // //

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -1,6 +1,6 @@
 /*
 ** Dn-FamiTracker - NES/Famicom sound tracker
-** Copyright (C) 2020-2025 D.P.C.M.
+** Copyright (C) 2020-2026 D.P.C.M.
 ** FamiTracker Copyright (C) 2005-2020 Jonathan Liss
 ** 0CC-FamiTracker Copyright (C) 2014-2018 HertzDevil
 **

--- a/Source/MainFrm.cpp
+++ b/Source/MainFrm.cpp
@@ -2496,21 +2496,21 @@ void CMainFrame::OnUpdateEditCut(CCmdUI *pCmdUI)
 
 void CMainFrame::OnUpdateEditCopy(CCmdUI *pCmdUI)
 {
-  CFamiTrackerView *pView = static_cast<CFamiTrackerView*>(GetActiveView());
-  bool patternEditorFocused = (GetFocus() == pView);
-  bool hasSelection = pView->IsSelecting();
+	CFamiTrackerView *pView = static_cast<CFamiTrackerView *>(GetActiveView());
+	bool patternEditorFocused = (GetFocus() == pView);
+	bool hasSelection = pView->IsSelecting();
 
-  // Check if the cursor is on a valid cell in the pattern editor
-  bool cursorValid = false;
-  if (patternEditorFocused) {
-    auto *pEditor = pView->GetPatternEditor();
-    const auto &cursor = pEditor->GetCursor();
-    int frameLen = pEditor->GetCurrentPatternLength(cursor.m_iFrame);
-    int channelCount = static_cast<CFamiTrackerDoc*>(GetActiveDocument())->GetAvailableChannels();
-    cursorValid = cursor.IsValid(frameLen, channelCount);
-  }
+	// Check if the cursor is on a valid cell in the pattern editor
+	bool cursorValid = false;
+	if (patternEditorFocused) {
+		auto *pEditor = pView->GetPatternEditor();
+		const auto &cursor = pEditor->GetCursor();
+		int frameLen = pEditor->GetCurrentPatternLength(cursor.m_iFrame);
+		int channelCount = static_cast<CFamiTrackerDoc *>(GetActiveDocument())->GetAvailableChannels();
+		cursorValid = cursor.IsValid(frameLen, channelCount);
+	}
 
-  pCmdUI->Enable(hasSelection || cursorValid);
+	pCmdUI->Enable(hasSelection || cursorValid);
 }
 
 void CMainFrame::OnUpdatePatternEditorSelected(CCmdUI *pCmdUI)		// // //

--- a/Source/PatternAction.cpp
+++ b/Source/PatternAction.cpp
@@ -180,6 +180,9 @@ std::optional<CSelection> CPatternAction::SetTargetSelection(CPatternEditor *pPa
 				End.m_iColumn = C_EFF4_PARAM2;
 		}
 	}
+	// column end beyond last effect param - assuming paste from copy without a selection and setting end to last effect param
+	if (End.m_iColumn > C_EFF4_PARAM2)
+		End.m_iColumn = C_EFF4_PARAM2;
 
 	Start.fixInvalid(*pPatternEditor->m_pDocument);
 	End.fixInvalid(*pPatternEditor->m_pDocument);

--- a/Source/PatternAction.cpp
+++ b/Source/PatternAction.cpp
@@ -180,9 +180,6 @@ std::optional<CSelection> CPatternAction::SetTargetSelection(CPatternEditor *pPa
 				End.m_iColumn = C_EFF4_PARAM2;
 		}
 	}
-	// column end beyond last effect param - assuming paste from copy without a selection and setting end to last effect param
-	if (End.m_iColumn > C_EFF4_PARAM2)
-		End.m_iColumn = C_EFF4_PARAM2;
 
 	Start.fixInvalid(*pPatternEditor->m_pDocument);
 	End.fixInvalid(*pPatternEditor->m_pDocument);

--- a/Source/PatternAction.cpp
+++ b/Source/PatternAction.cpp
@@ -1,6 +1,6 @@
 /*
 ** Dn-FamiTracker - NES/Famicom sound tracker
-** Copyright (C) 2020-2025 D.P.C.M.
+** Copyright (C) 2020-2026 D.P.C.M.
 ** FamiTracker Copyright (C) 2005-2020 Jonathan Liss
 ** 0CC-FamiTracker Copyright (C) 2014-2018 HertzDevil
 **

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -3590,8 +3590,8 @@ CPatternClipData *CPatternEditor::Copy() const
 	pSingleNote->ClipInfo.Rows = 1;
 
 	// Always copy note, instrument, volume, and all 4 effects
-	pSingleNote->ClipInfo.StartColumn = static_cast<column_t>(C_NOTE);
-	pSingleNote->ClipInfo.EndColumn = static_cast<column_t>(C_EFF4_PARAM2);
+	pSingleNote->ClipInfo.StartColumn = COLUMN_NOTE;
+	pSingleNote->ClipInfo.EndColumn = COLUMN_EFF4;
 
 	m_pDocument->GetNoteData(Track, Frame, Channel, Row, pSingleNote->GetPattern(0, 0));
 	return pSingleNote;

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -3550,32 +3550,51 @@ CPatternClipData *CPatternEditor::CopyEntire() const
 
 CPatternClipData *CPatternEditor::Copy() const
 {
-	// Copy selection
-	CPatternIterator it = GetIterators().first;		// // //
-	const int Channels	= m_selection.GetChanEnd() - m_selection.GetChanStart() + 1;
-	const int Rows		= GetSelectionSize();		// // //
-	stChanNote NoteData;
+  // Copy selection if selecting
+  if (m_bSelecting && GetSelectionSize() > 0) {
+    CPatternIterator it = GetIterators().first;		// // //
+    const int Channels = m_selection.GetChanEnd() - m_selection.GetChanStart() + 1;
+    const int Rows = GetSelectionSize();		// // //
+    stChanNote NoteData;
 
-	CPatternClipData *pClipData = new CPatternClipData(Channels, Rows);
-	pClipData->ClipInfo.Channels	= Channels;		// // //
-	pClipData->ClipInfo.Rows		= Rows;
-	pClipData->ClipInfo.StartColumn	= GetSelectColumn(m_selection.GetColStart());		// // //
-	pClipData->ClipInfo.EndColumn	= GetSelectColumn(m_selection.GetColEnd());		// // //
-	
-	for (int r = 0; r < Rows; r++) {		// // //
-		for (int i = 0; i < Channels; ++i) {
-			stChanNote *Target = pClipData->GetPattern(i, r);
-			it.Get(i + m_selection.GetChanStart(), &NoteData);
-			/*CopyNoteSection(Target, &NoteData, PASTE_DEFAULT,
+    CPatternClipData *pClipData = new CPatternClipData(Channels, Rows);
+    pClipData->ClipInfo.Channels	= Channels;		// // //
+	  pClipData->ClipInfo.Rows		= Rows;
+	  pClipData->ClipInfo.StartColumn	= GetSelectColumn(m_selection.GetColStart());		// // //
+	  pClipData->ClipInfo.EndColumn	= GetSelectColumn(m_selection.GetColEnd());		// // //
+
+    for (int r = 0; r < Rows; r++) {		// // //
+      for (int i = 0; i < Channels; ++i) {
+        stChanNote *Target = pClipData->GetPattern(i, r);
+        it.Get(i + m_selection.GetChanStart(), &NoteData);
+        /*CopyNoteSection(Target, &NoteData, PASTE_DEFAULT,
 				i == 0 ? ColStart : COLUMN_NOTE, i == Channels - 1 ? ColEnd : COLUMN_EFF4);*/
-			memcpy(Target, &NoteData, sizeof(stChanNote));
-			// the clip data should store the entire field;
-			// other methods should check ClipInfo.StartColumn and ClipInfo.EndColumn before operating
-		}
-		++it;
-	}
+			  memcpy(Target, &NoteData, sizeof(stChanNote));
+			  // the clip data should store the entire field;
+			  // other methods should check ClipInfo.StartColumn and ClipInfo.EndColumn before operating
+      }
+      ++it;
+    }
+    return pClipData;
+  }
 
-	return pClipData;
+  // If nothing is selected, copy the row under the cursor
+  const int Track = GetSelectedTrack();
+  const int Channel = m_cpCursorPos.m_iChannel;
+  const int Row = m_cpCursorPos.m_iRow;
+  const int Frame = m_cpCursorPos.m_iFrame;
+  const cursor_column_t Col = m_cpCursorPos.m_iColumn;
+
+  CPatternClipData *pSingleNote = new CPatternClipData(1, 1);
+  pSingleNote->ClipInfo.Channels = 1;
+  pSingleNote->ClipInfo.Rows = 1;
+
+  // Always copy note, instrument, volume, and all 4 effects
+  pSingleNote->ClipInfo.StartColumn = static_cast<column_t>(C_NOTE);
+  pSingleNote->ClipInfo.EndColumn = static_cast<column_t>(C_EFF4_PARAM2);
+
+  m_pDocument->GetNoteData(Track, Frame, Channel, Row, pSingleNote->GetPattern(0, 0));
+  return pSingleNote;
 }
 
 CPatternClipData *CPatternEditor::CopyRaw() const		// // //

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -3550,51 +3550,51 @@ CPatternClipData *CPatternEditor::CopyEntire() const
 
 CPatternClipData *CPatternEditor::Copy() const
 {
-  // Copy selection if selecting
-  if (m_bSelecting && GetSelectionSize() > 0) {
-    CPatternIterator it = GetIterators().first;		// // //
-    const int Channels = m_selection.GetChanEnd() - m_selection.GetChanStart() + 1;
-    const int Rows = GetSelectionSize();		// // //
-    stChanNote NoteData;
+	// Copy selection if selecting
+	if (m_bSelecting && GetSelectionSize() > 0) {
+		CPatternIterator it = GetIterators().first;		// // //
+		const int Channels = m_selection.GetChanEnd() - m_selection.GetChanStart() + 1;
+		const int Rows = GetSelectionSize();		// // //
+		stChanNote NoteData;
 
-    CPatternClipData *pClipData = new CPatternClipData(Channels, Rows);
-    pClipData->ClipInfo.Channels	= Channels;		// // //
-	  pClipData->ClipInfo.Rows		= Rows;
-	  pClipData->ClipInfo.StartColumn	= GetSelectColumn(m_selection.GetColStart());		// // //
-	  pClipData->ClipInfo.EndColumn	= GetSelectColumn(m_selection.GetColEnd());		// // //
+		CPatternClipData *pClipData = new CPatternClipData(Channels, Rows);
+		pClipData->ClipInfo.Channels = Channels;		// // //
+		pClipData->ClipInfo.Rows = Rows;
+		pClipData->ClipInfo.StartColumn = GetSelectColumn(m_selection.GetColStart());		// // //
+		pClipData->ClipInfo.EndColumn = GetSelectColumn(m_selection.GetColEnd());		// // //
 
-    for (int r = 0; r < Rows; r++) {		// // //
-      for (int i = 0; i < Channels; ++i) {
-        stChanNote *Target = pClipData->GetPattern(i, r);
-        it.Get(i + m_selection.GetChanStart(), &NoteData);
-        /*CopyNoteSection(Target, &NoteData, PASTE_DEFAULT,
-				i == 0 ? ColStart : COLUMN_NOTE, i == Channels - 1 ? ColEnd : COLUMN_EFF4);*/
-			  memcpy(Target, &NoteData, sizeof(stChanNote));
-			  // the clip data should store the entire field;
-			  // other methods should check ClipInfo.StartColumn and ClipInfo.EndColumn before operating
-      }
-      ++it;
-    }
-    return pClipData;
-  }
+		for (int r = 0; r < Rows; r++) {		// // //
+			for (int i = 0; i < Channels; ++i) {
+				stChanNote *Target = pClipData->GetPattern(i, r);
+				it.Get(i + m_selection.GetChanStart(), &NoteData);
+				/*CopyNoteSection(Target, &NoteData, PASTE_DEFAULT,
+						i == 0 ? ColStart : COLUMN_NOTE, i == Channels - 1 ? ColEnd : COLUMN_EFF4);*/
+				memcpy(Target, &NoteData, sizeof(stChanNote));
+				// the clip data should store the entire field;
+				// other methods should check ClipInfo.StartColumn and ClipInfo.EndColumn before operating
+			}
+			++it;
+		}
+		return pClipData;
+	}
 
-  // If nothing is selected, copy the row under the cursor
-  const int Track = GetSelectedTrack();
-  const int Channel = m_cpCursorPos.m_iChannel;
-  const int Row = m_cpCursorPos.m_iRow;
-  const int Frame = m_cpCursorPos.m_iFrame;
-  const cursor_column_t Col = m_cpCursorPos.m_iColumn;
+	// If nothing is selected, copy the row under the cursor
+	const int Track = GetSelectedTrack();
+	const int Channel = m_cpCursorPos.m_iChannel;
+	const int Row = m_cpCursorPos.m_iRow;
+	const int Frame = m_cpCursorPos.m_iFrame;
+	const cursor_column_t Col = m_cpCursorPos.m_iColumn;
 
-  CPatternClipData *pSingleNote = new CPatternClipData(1, 1);
-  pSingleNote->ClipInfo.Channels = 1;
-  pSingleNote->ClipInfo.Rows = 1;
+	CPatternClipData *pSingleNote = new CPatternClipData(1, 1);
+	pSingleNote->ClipInfo.Channels = 1;
+	pSingleNote->ClipInfo.Rows = 1;
 
-  // Always copy note, instrument, volume, and all 4 effects
-  pSingleNote->ClipInfo.StartColumn = static_cast<column_t>(C_NOTE);
-  pSingleNote->ClipInfo.EndColumn = static_cast<column_t>(C_EFF4_PARAM2);
+	// Always copy note, instrument, volume, and all 4 effects
+	pSingleNote->ClipInfo.StartColumn = static_cast<column_t>(C_NOTE);
+	pSingleNote->ClipInfo.EndColumn = static_cast<column_t>(C_EFF4_PARAM2);
 
-  m_pDocument->GetNoteData(Track, Frame, Channel, Row, pSingleNote->GetPattern(0, 0));
-  return pSingleNote;
+	m_pDocument->GetNoteData(Track, Frame, Channel, Row, pSingleNote->GetPattern(0, 0));
+	return pSingleNote;
 }
 
 CPatternClipData *CPatternEditor::CopyRaw() const		// // //


### PR DESCRIPTION
This pull request aims to add a feature to allow for coping a single row when no selection is available.

I always thought it was a bit annoying that `Ctrl+c` without a selection didn't do anything. Now it does something, it copies the entire row at once.

There is a crash if you copy a row without a selection, paste and then press delete, not sure what's going on there so I'm marking this as draft for now.

~~(If applicable) This pull request improves upon and supercedes `#<PR number>`.~~

### Changes in this PR:

- (cite all changes made in the PR for change log)
	- Feature (pattern editor): allow for copying single row in highlighted when no selection is available
