### PR TITLE
Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For more details, view the [license](LICENSE.md).
 
 ## Contributing
 
-[Contributing and compiling](Dn-FamiTracker/CONTRIBUTING.md)
+[Contributing and compiling](CONTRIBUTING.md)
 
 ## Program lineage
 


### PR DESCRIPTION
The current link leads to a 404