### PR TITLE
Optimizing N163 in NSF driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Last updated: January 11, 2026
 ### Improvements
 
 - Clarify NSF driver licensing (@Gumball2415 #401)
+- Replace addition loop to the actual multiplication (@HeeminTV #400)
+	- This worked before 0CC, which had table-per-instrument limit of 16, but as it's now 64, the usage of CPU cycles in this loop became massive
+- Slighly unroll the loop for writing to $4800 (@HeeminTV #400)
 
 ### Bug fixes
 
@@ -27,6 +30,7 @@ Last updated: January 11, 2026
 	- There doesn't seem to be any bug at the time of its writing upon further scrutiny.
 - Separate tempo state updating from channel state updating (@JG540 @Gumball2415 #382 #384 #394)
 - Set `m_iSpeed` to default when groove is enabled (@TakuikaNinja @Gumball2415 #379 #394)
+- Specify `byteorder` argument in `build_engine.py` for Python 3.10 compatibility (@HeeminTV #400)
 
 ### Internal
 

--- a/Source/drivers/asm/build/build_engine.py
+++ b/Source/drivers/asm/build/build_engine.py
@@ -127,13 +127,13 @@ def build(chip: str):
                 if x == y:
                     # NSFDRV
                     if len(t_nsfdrv) < 8:
-                        t_nsfdrv.append("0x%02X" % int.from_bytes(x))
+                        t_nsfdrv.append("0x%02X" % int.from_bytes(x, byteorder='little'))
                     # driver kernel
                     else:
-                        t_hed.append("0x%02X" % int.from_bytes(x))
+                        t_hed.append("0x%02X" % int.from_bytes(x, byteorder='little'))
                 else:
                     # pointer relocation
-                    t_hed.append("0x%02X" % (int.from_bytes(x)-0xC1))
+                    t_hed.append("0x%02X" % (int.from_bytes(x, byteorder='little')-0xC1))
                     reloc_query = in1.tell() - 1 - nsfdrv_size
                     if not reloc_lo.get(reloc_query) and not reloc_hi.get(reloc_query):
                         t_rel.append("0x%04X" % (reloc_query - 1))

--- a/Source/drivers/asm/n163.s
+++ b/Source/drivers/asm/n163.s
@@ -311,7 +311,6 @@ ft_n163_load_wave2:
 	bcc :+
 	;; !! !! if not, use wave_count - 1
 	lda (var_Temp_Pointer2), y
-	sec
 	sbc #1
 :
 	;;; ;; ; Multiply wave index with wave len
@@ -328,18 +327,38 @@ ft_n163_load_wave2:
 	adc var_Temp_Pointer2 + 1
 	sta var_Temp_Pointer2 + 1
 .else
-	sta var_Temp3
+	tay
 	lda	var_ch_WaveLen - N163_OFFSET, x
 	and #$7F
+
+	dey
+	sty var_Temp2
+	lsr
+	sta var_Temp3
+	lda #$00
+	ldy #$04
+@loop:	
+	bcc @skip
+	adc var_Temp2
+@skip:	
+	ror
+	ror var_Temp3
+	bcc @skip2
+	adc var_Temp2
+@skip2:
+	ror
+	ror var_Temp3
+	dey
+	bne @loop
+				
 	tay
-:   tya
+	lda var_Temp3
 	clc
 	adc var_Temp_Pointer2
 	sta var_Temp_Pointer2
-	bcc :+
-	inc var_Temp_Pointer2 + 1
-:	dec var_Temp3
-	bne :--
+	tya
+	adc var_Temp_Pointer2 + 1
+	sta var_Temp_Pointer2 + 1
 .endif
 @EndMul:		; ;; ;;;
 
@@ -347,11 +366,15 @@ ft_n163_load_wave2:
 	pha
 	lda var_ch_WaveLen - N163_OFFSET, x
 	and #$7F		;;; ;; ;
+	lsr
 	tax
 
 	; Load wave
 	ldy #$01		;; !! !!
 :	lda (var_Temp_Pointer2), y
+	sta $4800
+	iny
+	lda (var_Temp_Pointer2), y
 	sta $4800
 	iny
 	dex


### PR DESCRIPTION
This PR fixes the current driver with N163 enabled exceeding a frame (single 60Hz tick) by optimizing the waveform copying routine.

## Changes in this PR:
- Replaces addition loop to the actual multiplication (This worked before 0CC, which had table-per-instrument limit of 16, but as it's now 64, the usage of CPU cycles in this loop became massive)
- Slighly unrolls the loop for writing to $4800